### PR TITLE
Add HoopTrackr operating docs for CEO GPT replacement

### DIFF
--- a/docs/CEO_GPT_CONTEXT.md
+++ b/docs/CEO_GPT_CONTEXT.md
@@ -1,0 +1,228 @@
+# HoopTrackr CEO GPT Context
+
+This file is the canonical operating context for the GPT that will replace the old HoopTrackr CEO Custom GPT.
+
+## Mission
+
+Act as the CEO, product strategist, CTO assistant, QA lead, and growth advisor for HoopTrackr.
+
+The assistant should help Nabil move HoopTrackr from a working basketball tracking app into a focused, reliable, and commercially testable product.
+
+## Product identity
+
+- Product name: HoopTrackr
+- Repository: `nabilchaib/marker-app`
+- Current package name: `marker-app`
+- Brand style: basketball, energetic, mobile-first, orange/blue/cyan
+- Tagline: Track Your Game, Elevate Your Play
+- Preferred font from prior project memory: Audiowide
+
+## What HoopTrackr does
+
+HoopTrackr tracks basketball games, drills, teams, players, tournaments, and player statistics.
+
+The app should be useful during live basketball activity. Speed matters more than feature complexity. A scorer must be able to record events quickly without slowing the game down.
+
+## Core app areas
+
+- Landing page
+- Demo page
+- Firebase login/signup
+- Protected app shell with sidebar
+- Games list
+- Pickup game creation
+- Live pickup game tracking
+- Drill creation
+- Drill tracking
+- Teams CRUD
+- Players CRUD
+- Tournaments CRUD/detail
+- Game results
+- Player stats persistence
+- Analytics
+- Error monitoring
+
+## Current stack
+
+- React 18
+- Create React App
+- React Router DOM
+- Redux Toolkit
+- Redux Persist
+- Firebase Auth
+- Firestore
+- Firebase Storage
+- Firebase Hosting
+- Tailwind CSS
+- MUI
+- Headless UI
+- Heroicons
+- Emotion
+- Framer Motion
+- PostHog
+- Sentry
+- GitHub Actions
+
+## Current repository facts
+
+- Default branch: `master`
+- Direct commits to `master` are blocked; changes should go through PRs.
+- Dev deploy target: `hoop-trackr-development`
+- Production deploy target: `hoop-trackr`
+- Production deploy is manual through GitHub Actions workflow dispatch.
+- Player stats persistence depends on `REACT_APP_PERSIST_PLAYER_STATS=true`.
+
+## Strategic priority
+
+The current priority is to create a stronger operating system around the product.
+
+The assistant should help with:
+
+1. Product direction
+2. Roadmap maintenance
+3. GitHub issue and PR management
+4. Coding-agent ticket creation
+5. QA planning
+6. Release readiness
+7. Security and data model concerns
+8. Growth strategy
+9. Monetization experiments
+10. User research scripts
+
+## Product principles
+
+1. Fast scoring beats complete scoring.
+2. Mobile-first is mandatory.
+3. The scorer should never wonder which player/team is selected.
+4. Undo must be reliable and confidence-building.
+5. Stats must persist correctly.
+6. Data security is not optional.
+7. The first commercial wedge should be narrow.
+8. Product decisions should be validated with real basketball sessions.
+
+## Recommended first wedge
+
+Recommended near-term wedge: pickup players and small organized basketball groups.
+
+Reasons:
+
+- The current app already supports pickup game tracking.
+- It avoids slow institutional sales.
+- It creates immediate stats value.
+- It can be tested through Nabil's basketball network.
+- It can later expand into coaches, 3x3 leagues, and tournaments.
+
+## Other possible wedges
+
+- Youth coaches
+- Small teams
+- 3x3 leagues
+- Tournament organizers
+- Individual training and drill tracking
+
+## Current MVP definition
+
+A credible MVP should allow a user to:
+
+1. Sign up or log in.
+2. Create teams.
+3. Create players.
+4. Start a pickup game.
+5. Track shots, misses, rebounds, assists, fouls, and undo.
+6. End the game.
+7. View game results.
+8. Persist player stats.
+9. Track a drill session.
+10. Return later and see their data.
+
+## Known risks
+
+1. Firestore rules currently allow broad authenticated list/read access in some collections.
+2. Player stats persistence was recently fixed and needs regression tests.
+3. Game data shape may have legacy and current structures that need reconciliation.
+4. CRA is aging, though still functional.
+5. The monetization model is not yet validated.
+6. Mobile scoring UX needs live testing.
+7. Test coverage is not yet strong enough for confident releases.
+
+## How to review PRs
+
+When reviewing a HoopTrackr PR, check:
+
+- Does it preserve fast scoring UX?
+- Does it affect game/drill stat correctness?
+- Does it affect persistence?
+- Does it create cross-user data exposure?
+- Does it break mobile layout?
+- Does it introduce unclear user flows?
+- Does it update docs if product behavior changed?
+- Does it require QA checklist updates?
+- Does it affect deploy workflows or env vars?
+
+## How to create coding-agent tickets
+
+A coding-agent ticket should include:
+
+- Context
+- Goal
+- Files likely involved
+- Acceptance criteria
+- Test plan
+- Non-goals
+- Risk notes
+
+Avoid vague prompts like “improve the app.” Prefer focused tickets like:
+
+> Tighten Firestore list/read rules so users can only access their own teams, players, games, player_stats, and tournaments. Update queries if needed. Add emulator tests or clear manual verification steps for two users.
+
+## Near-term issue backlog
+
+### Security hardening
+
+Tighten Firestore rules so authenticated users cannot list/read other users' records.
+
+### Stats regression tests
+
+Add tests around game scoring, undo, drill tracking, and player stats persistence.
+
+### Product wedge decision
+
+Select and document the first commercial wedge.
+
+### Mobile scoring field test
+
+Run HoopTrackr during a real pickup game and record scoring friction.
+
+### Monetization hypothesis
+
+Define the first free/paid boundary and upgrade prompt strategy.
+
+## Output style for the assistant
+
+The assistant should be practical, founder-oriented, and action-driven.
+
+Prefer:
+
+- concise diagnosis
+- clear recommendations
+- explicit tradeoffs
+- issue-ready tasks
+- PR review summaries
+- QA checklists
+- product strategy memos
+
+Avoid:
+
+- generic startup advice
+- large vague roadmaps with no next action
+- technical rewrites without business reason
+- monetization ideas disconnected from current product behavior
+
+## Current next best action
+
+Merge the documentation PR, then create and prioritize the first hardening issues:
+
+1. Firestore security tightening
+2. Stats and undo regression tests
+3. First commercial wedge decision
+4. Mobile live-scoring field test

--- a/docs/PROJECT_BRIEF.md
+++ b/docs/PROJECT_BRIEF.md
@@ -1,0 +1,199 @@
+# HoopTrackr Project Brief
+
+## Identity
+
+HoopTrackr is a basketball tracking app in the GitHub repository `nabilchaib/marker-app`. The repository package name is still `marker-app`, but the product brand is HoopTrackr / Hoop Trackr.
+
+The product helps basketball players, coaches, organizers, and pickup groups track games, drills, teams, players, tournaments, and player statistics in real time.
+
+Current positioning:
+
+> Track Your Game, Elevate Your Play
+
+Current landing-page promise:
+
+> The ultimate basketball companion for tracking games, drills, and player stats in real-time.
+
+## Product vision
+
+HoopTrackr should become the easiest way to capture useful basketball performance data during real games and training sessions without slowing down the game.
+
+The product should be fast enough for a live scorer, simple enough for pickup runs, and structured enough for coaches, youth teams, 3x3 leagues, and tournament organizers.
+
+## Current stack
+
+- React 18 / Create React App
+- React Router DOM
+- Redux Toolkit
+- Redux Persist
+- Firebase Auth
+- Firestore
+- Firebase Storage
+- Firebase Hosting
+- Tailwind CSS
+- MUI
+- Headless UI
+- Heroicons
+- Emotion
+- Framer Motion
+- PostHog analytics
+- Sentry error tracking
+- GitHub Actions CI/deploy
+
+## Firebase environments
+
+- Development Firebase Hosting project: `hoop-trackr-development`
+- Production Firebase Hosting project: `hoop-trackr`
+
+## Core product areas
+
+### Marketing and onboarding
+
+- Landing page
+- Demo page
+- Login/signup through Firebase Auth
+- Protected app routes for authenticated users
+
+### Team and player management
+
+- Create, edit, list, and delete teams
+- Create, edit, list, and delete players
+- Player and team avatar upload through Firebase Storage
+
+### Pickup game tracking
+
+- Create pickup games
+- Select teams
+- Select players
+- Track made shots: free throws, 2-pointers, 3-pointers
+- Track missed shots / attempts
+- Track rebounds
+- Track assists
+- Track fouls
+- Undo last action
+- View last actions
+- View game results
+- End game
+
+### Drill tracking
+
+- Create drills
+- Select players
+- Track made attempts / completions
+- Track misses / attempts
+- Calculate success rate
+- View drill results
+
+### Tournaments
+
+- Create tournaments
+- List tournaments
+- View tournament detail
+- Update and delete tournaments
+
+### Analytics and observability
+
+- PostHog user identification and event capture
+- Sentry initialization and ErrorBoundary
+- Existing analytics helpers:
+  - `signed_up`
+  - `game_started`
+  - `game_finished`
+  - `drill_started`
+  - `drill_finished`
+  - `upgrade_prompt_shown`
+
+## Data model overview
+
+Main Firestore collections currently used or referenced:
+
+- `users`
+- `players`
+- `teams`
+- `game`
+- `player_stats`
+- `tournaments`
+
+Game stats include:
+
+- threes
+- twos
+- free throws
+- attempted threes
+- attempted twos
+- attempted free throws
+- offensive rebounds
+- defensive rebounds
+- assists
+- fouls
+
+Drill stats include:
+
+- attempts
+- completions
+
+## Brand notes
+
+- Product name: HoopTrackr
+- Preferred brand font from prior product decisions: Audiowide
+- Key colors:
+  - Orange: `#f64e07`
+  - Dark blue: `#0a355e`
+  - Cyan: `#0aa6d6`
+- PWA style: mobile-first, portrait orientation, standalone display
+
+## Current maturity assessment
+
+HoopTrackr is past prototype and has the foundations of an MVP:
+
+- Authentication exists
+- Team and player management exists
+- Pickup game tracking exists
+- Drill tracking exists
+- Tournament functionality exists
+- Firebase persistence exists
+- Player stat persistence has been recently hardened
+- Analytics exists
+- Error monitoring exists
+- Dev and production deploy workflows exist
+
+However, HoopTrackr is not yet a fully hardened production SaaS. The next phase should focus on reliability, security, regression tests, mobile scoring UX, onboarding clarity, and a clear first commercial wedge.
+
+## Current strategic priority
+
+The next version of the HoopTrackr operating system should replace the old HoopTrackr CEO Custom GPT. The new assistant should act as a CEO / product / technical operating layer for the project.
+
+It should help with:
+
+- Product strategy
+- Roadmap management
+- GitHub PR review
+- Coding-agent tickets
+- Technical architecture decisions
+- QA and release readiness
+- Monetization experiments
+- Growth and marketing copy
+- User segment selection
+- Investor/founder-style reporting
+
+## Most important risks to watch
+
+1. Firestore rules currently allow broad authenticated reads/lists on several collections. This should be tightened so users cannot list other users' private data.
+2. Stats persistence was recently fixed and should receive regression coverage.
+3. The codebase has evolved from an early scoreboard into a broader product; older game structures and newer Redux structures should be reconciled.
+4. The scoring UI must remain extremely fast on mobile. Basketball tracking fails if the scorer needs too many taps.
+5. CRA is workable but aging. A future migration to Vite, Next.js, or a stronger PWA setup may eventually be valuable.
+6. Monetization is not yet fully defined, even though analytics contains an upgrade prompt event.
+
+## Next operating question
+
+The main product strategy decision is the first wedge:
+
+- Pickup players
+- Youth coaches
+- Small teams
+- 3x3 leagues
+- Tournament organizers
+- Individual training / drills
+
+The recommended near-term wedge is to validate pickup games plus small organized groups first, while keeping coaches and tournament organizers as the next expansion path.

--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -1,0 +1,230 @@
+# HoopTrackr QA Checklist
+
+This checklist is the minimum product and technical QA pass before treating HoopTrackr as production-ready for real users.
+
+## 1. Environment and setup
+
+- [ ] `npm ci` completes successfully.
+- [ ] `npm start` runs the app locally with development environment variables.
+- [ ] `npm run build` completes successfully.
+- [ ] Firebase development environment points to `hoop-trackr-development`.
+- [ ] Firebase production environment points to `hoop-trackr`.
+- [ ] Required env vars are documented and available for dev/prod.
+- [ ] Sentry is disabled safely when `REACT_APP_SENTRY_DSN` is absent.
+- [ ] PostHog is disabled safely when `REACT_APP_POSTHOG_KEY` is absent.
+
+## 2. Authentication
+
+- [ ] Logged-out users are redirected to `/landing` when trying to access protected app routes.
+- [ ] Logged-in users are redirected away from `/login`.
+- [ ] New users are created or found through `addOrGetUserApi`.
+- [ ] User is identified in PostHog after login when analytics is configured.
+- [ ] User data is reset from Redux on logout.
+- [ ] Refreshing the browser preserves expected authenticated app state.
+
+## 3. New user onboarding
+
+- [ ] A user with no teams sees a useful empty state.
+- [ ] A user with no players sees a useful empty state.
+- [ ] User can create a team from the empty state.
+- [ ] User can create a player from the empty state.
+- [ ] User understands what to do before starting a first game.
+
+## 4. Team management
+
+- [ ] User can create a team.
+- [ ] Duplicate team name handling works for the same user.
+- [ ] User can upload a team avatar.
+- [ ] User can edit a team.
+- [ ] User can delete a team.
+- [ ] Deleting a team removes the related avatar object when present.
+- [ ] Team list only shows teams belonging to the current user.
+- [ ] Team form errors are visible and understandable.
+
+## 5. Player management
+
+- [ ] User can create a player.
+- [ ] User can assign a player to a team.
+- [ ] User can add player number.
+- [ ] User can upload player avatar.
+- [ ] User can edit a player.
+- [ ] User can delete a player.
+- [ ] Deleting a player removes the related avatar object when present.
+- [ ] Player list only shows players belonging to the current user.
+- [ ] Player form errors are visible and understandable.
+
+## 6. Pickup game creation
+
+- [ ] User can create a pickup game.
+- [ ] User can select Team A and Team B.
+- [ ] App prevents or handles selecting the same team twice.
+- [ ] App handles teams with no players.
+- [ ] Initial score is 0-0.
+- [ ] Initial stats are empty or zeroed.
+- [ ] Created game appears in game list.
+- [ ] Created game opens correctly from game list.
+
+## 7. Live pickup game tracking
+
+For each action, verify both the UI and underlying Redux state.
+
+### Scoring
+
+- [ ] Made free throw adds 1 point.
+- [ ] Made 2-pointer adds 2 points.
+- [ ] Made 3-pointer adds 3 points.
+- [ ] Missed free throw increments attempted free throws.
+- [ ] Missed 2-pointer increments attempted twos.
+- [ ] Missed 3-pointer increments attempted threes.
+- [ ] Made shots also count as attempts if this is the intended product rule.
+- [ ] Team score updates for the correct team.
+- [ ] Player stats update for the correct player.
+
+### Other stats
+
+- [ ] Offensive rebound increments offensive rebounds.
+- [ ] Defensive rebound increments defensive rebounds, if exposed in UI.
+- [ ] Assist increments assists.
+- [ ] Foul increments fouls.
+- [ ] Last action table records each action.
+
+### Selection state
+
+- [ ] Selected team is visually obvious.
+- [ ] Selected player is visually obvious.
+- [ ] Changing team clears or updates selected player correctly.
+- [ ] User cannot accidentally assign a stat to the wrong team/player without clear feedback.
+
+## 8. Undo behavior
+
+- [ ] Undo made free throw removes 1 point and decrements stat.
+- [ ] Undo made 2-pointer removes 2 points and decrements stat.
+- [ ] Undo made 3-pointer removes 3 points and decrements stat.
+- [ ] Undo missed free throw decrements attempted free throws.
+- [ ] Undo missed 2-pointer decrements attempted twos.
+- [ ] Undo missed 3-pointer decrements attempted threes.
+- [ ] Undo rebound decrements correct rebound type.
+- [ ] Undo assist decrements assists.
+- [ ] Undo foul decrements fouls.
+- [ ] Undo drill completion decrements attempts and completions.
+- [ ] Undo drill attempt decrements attempts.
+- [ ] Undo with no actions does not crash.
+- [ ] Undo cannot produce negative stats.
+
+## 9. Game results and end game
+
+- [ ] Game results modal opens.
+- [ ] Game results show team scores.
+- [ ] Game results show player stats.
+- [ ] Back/close returns to game tracking.
+- [ ] End game marks the game as finished.
+- [ ] End game writes expected fields to Firestore.
+- [ ] End game persists player stats when `REACT_APP_PERSIST_PLAYER_STATS=true`.
+- [ ] Ending the same game twice does not create duplicate player stat records.
+- [ ] Finished game no longer appears as an active unfinished game.
+
+## 10. Drill creation and tracking
+
+- [ ] User can create a drill.
+- [ ] User can select one or more players, depending on current supported behavior.
+- [ ] Drill opens correctly.
+- [ ] Made increments attempts and completions.
+- [ ] Miss increments attempts only.
+- [ ] Success rate is calculated correctly.
+- [ ] Drill result view shows attempts, completions, and success rate.
+- [ ] Drill can be ended.
+- [ ] Drill stats persist if persistence is enabled.
+
+## 11. Tournament flow
+
+- [ ] User can create a tournament.
+- [ ] Required tournament fields validate correctly.
+- [ ] Tournament appears in list.
+- [ ] Tournament detail page opens.
+- [ ] User can update tournament.
+- [ ] User can delete tournament.
+- [ ] Tournament list only shows tournaments belonging to the current user.
+
+## 12. Persistence and refresh behavior
+
+- [ ] Refresh during game tracking restores expected game state.
+- [ ] Refresh after creating teams/players preserves expected state.
+- [ ] Redux Persist does not leak state between users after logout/login.
+- [ ] Firestore and Redux remain consistent after end game.
+- [ ] Offline/poor network behavior is understandable to the user.
+
+## 13. Firestore security
+
+Use at least two test users.
+
+- [ ] User A cannot read User B players.
+- [ ] User A cannot list User B players.
+- [ ] User A cannot update User B players.
+- [ ] User A cannot delete User B players.
+- [ ] User A cannot read User B teams.
+- [ ] User A cannot list User B teams.
+- [ ] User A cannot update User B teams.
+- [ ] User A cannot delete User B teams.
+- [ ] User A cannot read User B games.
+- [ ] User A cannot list User B games.
+- [ ] User A cannot update User B games.
+- [ ] User A cannot delete User B games.
+- [ ] User A cannot read User B player stats.
+- [ ] User A cannot list User B player stats.
+- [ ] User A cannot update User B player stats.
+- [ ] User A cannot delete User B player stats.
+- [ ] User A cannot read User B tournaments.
+- [ ] User A cannot list User B tournaments.
+- [ ] User A cannot update User B tournaments.
+- [ ] User A cannot delete User B tournaments.
+
+## 14. Analytics
+
+- [ ] `signed_up` fires when a new user is created.
+- [ ] `game_started` fires when a game starts.
+- [ ] `game_finished` fires when a game finishes.
+- [ ] `drill_started` fires when a drill starts.
+- [ ] `drill_finished` fires when a drill finishes.
+- [ ] `upgrade_prompt_shown` fires when monetization prompts are shown.
+- [ ] Analytics does not block app behavior when PostHog is unavailable.
+
+## 15. Sentry and error handling
+
+- [ ] Sentry initializes only when DSN is present.
+- [ ] ErrorBoundary fallback renders if a page crashes.
+- [ ] User-facing errors are clear and non-technical.
+- [ ] Critical Firebase failures are logged.
+- [ ] Common failed operations show a toast or clear feedback.
+
+## 16. Mobile scoring UX
+
+- [ ] Main scoring buttons are easy to tap on a phone.
+- [ ] Buttons are not too close together.
+- [ ] Selected team/player state is visible without scrolling.
+- [ ] Game controls do not require excessive vertical scrolling.
+- [ ] UI works in portrait orientation.
+- [ ] Scoring can keep up with a real pickup game.
+- [ ] Undo is easy to find but not too easy to hit accidentally.
+
+## 17. PWA behavior
+
+- [ ] Manifest loads correctly.
+- [ ] App has correct name: HoopTrackr.
+- [ ] App icons load.
+- [ ] Theme color appears correctly.
+- [ ] App can be installed where supported.
+- [ ] Installed app opens to expected route.
+
+## 18. Release checklist
+
+Before each release:
+
+- [ ] Review merged PRs since last release.
+- [ ] Run build.
+- [ ] Run automated tests if available.
+- [ ] Run manual smoke test.
+- [ ] Confirm dev deploy works.
+- [ ] Confirm production deploy is manual and intentional.
+- [ ] Check Sentry after release.
+- [ ] Check PostHog events after release.
+- [ ] Document known issues.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,246 @@
+# HoopTrackr Roadmap
+
+## Roadmap principles
+
+HoopTrackr should optimize for speed, clarity, and trust.
+
+A basketball scorer should be able to record an action in one or two taps while the game keeps moving. A player or coach should be able to trust that the stats are accurate, persisted, and easy to review later.
+
+This roadmap is organized around product maturity rather than calendar dates.
+
+## Phase 0 — Stabilize the operating foundation
+
+Goal: make the current app understandable, maintainable, and ready for product decisions.
+
+### Outcomes
+
+- Clear project documentation exists in the repository.
+- Product, tech, QA, and CEO GPT context are documented.
+- Current risks are visible.
+- Future coding agents can work from shared context.
+
+### Work
+
+- Add `docs/PROJECT_BRIEF.md`.
+- Add `docs/ROADMAP.md`.
+- Add `docs/QA_CHECKLIST.md`.
+- Add `docs/CEO_GPT_CONTEXT.md`.
+- Keep README focused on local setup and deployment.
+- Create follow-up issues for security hardening, regression tests, and wedge selection.
+
+### Done when
+
+- Documentation PR is merged.
+- Follow-up issues exist.
+- The CEO GPT can use the repo docs as canonical context.
+
+## Phase 1 — Harden the MVP
+
+Goal: make the existing app reliable enough for repeated real-world scoring sessions.
+
+### Product scope
+
+- Pickup game tracking
+- Drill tracking
+- Teams
+- Players
+- Game results
+- Basic tournament support
+
+### Technical work
+
+- Tighten Firestore rules so users cannot list or read other users' private records.
+- Confirm all queries are scoped by `createdBy` or equivalent ownership fields.
+- Add regression coverage for:
+  - made shot
+  - missed shot / attempt
+  - rebound
+  - assist
+  - foul
+  - undo
+  - drill attempt
+  - drill completion
+  - end game
+  - player stats persistence
+- Add test fixtures for game, team, player, drill, and tournament state.
+- Audit old game shape vs current Redux game shape.
+- Remove stale or unused code paths where safe.
+- Confirm production build and manual production deploy still work.
+
+### Product QA work
+
+- Test with one real pickup game.
+- Test with one real drill session.
+- Record all scoring friction points.
+- Measure how many taps are needed for common actions.
+
+### Done when
+
+- A user can create teams/players, track a full pickup game, end it, and later see persisted stats.
+- A user can track a drill session and see results.
+- Cross-user data access is blocked at the rules level.
+- The core scoring flow survives refresh/reload without data loss.
+
+## Phase 2 — Improve live scoring UX
+
+Goal: make the scorer experience fast enough for real basketball.
+
+### Product work
+
+- Optimize mobile layout for one-handed use.
+- Make selected team and selected player always obvious.
+- Reduce taps for common actions.
+- Improve undo confidence.
+- Add clearer game clock or session context if needed.
+- Improve empty states for new users with no teams or players.
+- Improve game result readability.
+
+### UX questions
+
+- Should scorer select player first, then stat?
+- Should scorer select stat first, then player?
+- Should there be a quick player grid for each team?
+- Should missed shots be tracked as separate attempt buttons or as a made/miss pair?
+- Should rebounds distinguish offensive/defensive in the first MVP?
+
+### Done when
+
+- A scorer can track live pickup action without falling behind.
+- The main scoring actions are reachable with minimal cognitive load.
+- The app feels mobile-native even though it is web/PWA-based.
+
+## Phase 3 — Pick the first commercial wedge
+
+Goal: decide who HoopTrackr should serve first.
+
+### Candidate wedges
+
+1. Pickup players and recurring pickup groups
+2. Youth coaches and small teams
+3. 3x3 leagues
+4. Tournament organizers
+5. Individual training / drill tracking
+
+### Recommended first wedge
+
+Start with pickup players plus small organized groups.
+
+Why:
+
+- This matches the original product energy.
+- It requires less institutional sales than schools or leagues.
+- It creates real game data quickly.
+- It can expand naturally into team and tournament use.
+- The user already has basketball/referee/community context.
+
+### Validation questions
+
+- Who is willing to score the game?
+- What stats do players actually care about after the game?
+- Would a pickup group share the app after one good session?
+- Is the value individual pride, team organization, player development, or league credibility?
+- What feature would make users return next week?
+
+### Done when
+
+- One target persona is selected.
+- The landing page speaks directly to that persona.
+- The first pricing hypothesis is documented.
+- The first user test script is ready.
+
+## Phase 4 — Monetization experiment
+
+Goal: test whether users will pay or upgrade.
+
+### Possible free tier
+
+- Create teams and players
+- Track limited games per month
+- Track limited drills per month
+- Basic game results
+
+### Possible paid features
+
+- Unlimited games
+- Unlimited drill history
+- Player stat history
+- Team dashboards
+- Tournament mode
+- Export/share game reports
+- Advanced shooting charts
+- Multiple scorers/admins
+- Branded league pages
+
+### Analytics needed
+
+- signup completed
+- first team created
+- first player created
+- first game started
+- first game finished
+- first drill started
+- first drill finished
+- game results viewed
+- upgrade prompt shown
+- upgrade CTA clicked
+
+### Done when
+
+- A simple pricing hypothesis exists.
+- Upgrade prompts are tied to real usage limits.
+- Analytics can show activation and retention.
+
+## Phase 5 — Coach/team layer
+
+Goal: expand from pickup tracking to structured development.
+
+### Features
+
+- Player profiles with stat history
+- Team dashboard
+- Drill history by player
+- Shooting splits
+- Player comparison
+- Coach notes
+- Exportable player report
+
+### Done when
+
+- Coaches can use HoopTrackr to review player progress.
+- Players have a reason to keep their profile over time.
+
+## Phase 6 — Tournament and league layer
+
+Goal: support organized 3x3 or small basketball events.
+
+### Features
+
+- Tournament brackets or pools
+- Game schedule
+- Team registration
+- Standings
+- Public results page
+- Shareable tournament link
+- Organizer dashboard
+
+### Done when
+
+- A small tournament can be run end to end using HoopTrackr.
+
+## Phase 7 — Platform modernization
+
+Goal: reduce technical drag and prepare for scale.
+
+### Possible work
+
+- Evaluate CRA to Vite migration.
+- Evaluate PWA install improvements.
+- Evaluate Next.js only if server-rendered marketing, SEO, or backend routes become important.
+- Improve test suite.
+- Improve CI quality gates.
+- Add stronger type coverage over time.
+
+### Done when
+
+- The frontend stack feels fast and maintainable.
+- New features can be shipped safely.


### PR DESCRIPTION
## Summary

Adds the initial HoopTrackr operating documentation needed to replace the old HoopTrackr CEO Custom GPT with a stronger product/technical operating assistant.

## Added

- `docs/PROJECT_BRIEF.md` — canonical project identity, product scope, stack, brand, maturity, risks, and strategic priority
- `docs/ROADMAP.md` — phased roadmap from documentation foundation through MVP hardening, UX, wedge selection, monetization, coach/team layer, tournaments, and platform modernization
- `docs/QA_CHECKLIST.md` — manual QA checklist for auth, onboarding, teams, players, pickup game tracking, drills, tournaments, persistence, Firestore security, analytics, Sentry, mobile UX, PWA, and release readiness
- `docs/CEO_GPT_CONTEXT.md` — canonical context file for the new HoopTrackr CEO/Product/CTO GPT

## Why

The project has evolved from a marker/scoreboard prototype into a broader basketball tracking product. These docs give future coding agents and the replacement GPT a shared operating base.

## Follow-up work

- Tighten Firestore read/list rules and verify cross-user isolation
- Add regression tests for scoring, undo, drills, and player stats persistence
- Decide the first commercial wedge
- Run a mobile live-scoring field test
- Define the first monetization hypothesis

## Test plan

Docs-only change.

- [ ] Review docs for accuracy
- [ ] Confirm no app behavior changed
