### PR TITLE
Fix game/drill persistence, createdBy, security rules, and add regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Lint
         run: npm run lint --if-present
 
+      - name: Test
+        run: npm test -- --watchAll=false
+        env:
+          CI: true
+
       - name: Build
         run: npm run build
         env:

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,43 +10,49 @@ service cloud.firestore {
       return request.auth.token.email == resource.data.createdBy;
     }
 
-    // Users: authenticated users can read/write their own record
+    function isCreatingOwned() {
+      return request.auth.token.email == request.resource.data.createdBy;
+    }
+
+    // Users: a user can only read/write their own record
     match /users/{userId} {
-      allow read, write: if isAuthenticated();
+      allow get, list: if isAuthenticated() && resource.data.email == request.auth.token.email;
+      allow create: if isAuthenticated() && request.resource.data.email == request.auth.token.email;
+      allow update, delete: if isAuthenticated() && resource.data.email == request.auth.token.email;
     }
 
-    // Players: creator owns; anyone authenticated can create
+    // Players: owner-only read/list/update/delete; must set createdBy on create
     match /players/{playerId} {
-      allow get, list: if isAuthenticated();
-      allow create: if isAuthenticated();
+      allow get, list: if isAuthenticated() && isOwner();
+      allow create: if isAuthenticated() && isCreatingOwned();
       allow update, delete: if isAuthenticated() && isOwner();
     }
 
-    // Teams: creator owns; anyone authenticated can create
+    // Teams: owner-only read/list/update/delete; must set createdBy on create
     match /teams/{teamId} {
-      allow get, list: if isAuthenticated();
-      allow create: if isAuthenticated();
+      allow get, list: if isAuthenticated() && isOwner();
+      allow create: if isAuthenticated() && isCreatingOwned();
       allow update, delete: if isAuthenticated() && isOwner();
     }
 
-    // Games: creator owns; authenticated users can create
+    // Games: owner-only read/list/update/delete; must set createdBy on create
     match /game/{gameId} {
-      allow get, list: if isAuthenticated();
-      allow create: if isAuthenticated();
+      allow get, list: if isAuthenticated() && isOwner();
+      allow create: if isAuthenticated() && isCreatingOwned();
       allow update, delete: if isAuthenticated() && isOwner();
     }
 
-    // Player stats: creator owns; authenticated users can create
+    // Player stats: owner-only read/list/update/delete; must set createdBy on create
     match /player_stats/{statId} {
-      allow get, list: if isAuthenticated();
-      allow create: if isAuthenticated();
+      allow get, list: if isAuthenticated() && isOwner();
+      allow create: if isAuthenticated() && isCreatingOwned();
       allow update, delete: if isAuthenticated() && isOwner();
     }
 
-    // Tournaments: creator owns; anyone authenticated can create
+    // Tournaments: owner-only read/list/update/delete; must set createdBy on create
     match /tournaments/{tournamentId} {
-      allow get, list: if isAuthenticated();
-      allow create: if isAuthenticated();
+      allow get, list: if isAuthenticated() && isOwner();
+      allow create: if isAuthenticated() && isCreatingOwned();
       allow update, delete: if isAuthenticated() && isOwner();
     }
   }

--- a/src/components/ManualScoreModal.js
+++ b/src/components/ManualScoreModal.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { v4 as uuid } from 'uuid';
 import { addNewGame } from '../redux/games-reducer';
 import { addGameToTournament, updateTournamentMatch } from '../redux/tournaments-reducer';
 import { addGameApi, updateTournamentApi } from '../firebase/api';
@@ -37,7 +36,6 @@ const ManualScoreModal = ({ isOpen, onClose, tournamentId, round, matchIndex, te
     try {
       // Create a new game with the manual scores
       const newGame = {
-        id: uuid(),
         teamAId: teamA.id,
         teamBId: teamB.id,
         teamAName: teamA.name,
@@ -48,7 +46,6 @@ const ManualScoreModal = ({ isOpen, onClose, tournamentId, round, matchIndex, te
         type: 'pick-up',
         teamAScore: scoreA,
         teamBScore: scoreB,
-        notSaved: true,
         stats: {},
         players: {},
         tournamentId: tournamentId,

--- a/src/firebase/api.js
+++ b/src/firebase/api.js
@@ -3,6 +3,7 @@ import {
   addDoc,
   getDocs,
   deleteDoc,
+  setDoc,
   query,
   collection,
   where,
@@ -107,15 +108,14 @@ export const initializeGameApi = async (selectedTeams, mode = "game") => {
   });
 };
 export const addGameApi = async (game) => {
-  console.log('addGameApi called with:', game);
   try {
-    const gameToAdd = game.date ? game : {...game, date:serverTimestamp()}
+    const { id: _localId, notSaved: _notSaved, ...gameData } = game;
+    const gameToAdd = gameData.date ? gameData : { ...gameData, date: serverTimestamp() };
     const gameRef = collection(db, 'game');
-    const newGameRef = await addDoc(gameRef, gameToAdd)
+    const newGameRef = await addDoc(gameRef, gameToAdd);
     const newGameSnapshot = await getDoc(newGameRef);
     const newGameData = newGameSnapshot.data();
-    
-    // Safely handle the date conversion
+
     let dateString;
     if (newGameData.date) {
       if (typeof newGameData.date.toDate === 'function') {
@@ -127,13 +127,7 @@ export const addGameApi = async (game) => {
       }
     }
 
-    const newGame = {
-      id: newGameRef.id,
-      ...newGameData,
-      date: dateString,
-      players: game.players  // Ensure players structure is included in the return object
-    };
-    return newGame;
+    return { ...newGameData, id: newGameRef.id, date: dateString };
   } catch (err) {
     console.error('ADD GAME API ERR: ', err);
     throw new Error('Failed to save game to database');
@@ -456,7 +450,7 @@ export const pushStatsToFirebase = async (game, teamA, teamB) => {
   // Set REACT_APP_PERSIST_PLAYER_STATS=true in .env to enable.
   if (process.env.REACT_APP_PERSIST_PLAYER_STATS !== 'true') {
     const gameRef = doc(db, 'game', game.id);
-    await updateDoc(gameRef, { finished: true, endedAt: serverTimestamp() });
+    await setDoc(gameRef, { finished: true, endedAt: serverTimestamp() }, { merge: true });
     return;
   }
 
@@ -515,7 +509,7 @@ export const pushStatsToFirebase = async (game, teamA, teamB) => {
     }
 
     const gameRef = doc(db, 'game', game.id);
-    batch.update(gameRef, { finished: true, endedAt: serverTimestamp() });
+    batch.set(gameRef, { finished: true, endedAt: serverTimestamp() }, { merge: true });
 
     await batch.commit();
   } catch (err) {

--- a/src/pages/AddDrill/index.js
+++ b/src/pages/AddDrill/index.js
@@ -2,10 +2,9 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
-import { v4 as uuid } from 'uuid';
 
 import Icon from '../../components/Icon';
-import { getPlayersApi } from '../../firebase/api';
+import { getPlayersApi, addGameApi } from '../../firebase/api';
 import { addPlayers } from '../../redux/players-reducer';
 import { addNewGame } from '../../redux/games-reducer';
 import { trackDrillStarted } from '../../analytics';
@@ -15,6 +14,7 @@ export default function AddDrill() {
   const dispatch = useDispatch();
 
   const [getPlayersLoading, setGetPlayersLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
   const user = useSelector(state => state.user);
   const players = useSelector(state => state.players);
 
@@ -46,7 +46,7 @@ export default function AddDrill() {
     );
   };
 
-  const onStartDrill = () => {
+  const onStartDrill = async () => {
     if (selectedPlayers.length === 0) {
       toast.error('Select at least one player to start the drill', {
         position: 'top-center',
@@ -54,20 +54,26 @@ export default function AddDrill() {
       return;
     }
 
-    const newDrill = {
-      id: uuid(),
-      playerIds: selectedPlayers,
-      type: 'drill',
-      createdBy: user.id,
-      createdOn: new Date().getTime(),
-      actions: [],
-      notSaved: true,
-      stats: {},
-    };
-
-    dispatch(addNewGame(newDrill));
-    trackDrillStarted();
-    navigate(`/games/drill/${newDrill.id}`);
+    setSaving(true);
+    try {
+      const drillData = {
+        playerIds: selectedPlayers,
+        type: 'drill',
+        createdBy: user.email,
+        createdOn: new Date().getTime(),
+        actions: [],
+        stats: {},
+      };
+      const savedDrill = await addGameApi(drillData);
+      dispatch(addNewGame(savedDrill));
+      trackDrillStarted();
+      navigate(`/games/drill/${savedDrill.id}`);
+    } catch (err) {
+      console.error('CREATE DRILL ERR:', err);
+      toast.error('Failed to create drill. Please try again.', { position: 'top-center' });
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -144,10 +150,11 @@ export default function AddDrill() {
       <div className="mt-6">
         <button
           type="button"
-          className="w-full sm:w-auto inline-flex items-center rounded-md bg-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-orange-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600"
+          disabled={saving}
+          className="w-full sm:w-auto inline-flex items-center rounded-md bg-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-orange-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600 disabled:opacity-60 disabled:cursor-not-allowed"
           onClick={onStartDrill}
         >
-          Start Drill
+          {saving ? 'Creating...' : 'Start Drill'}
         </button>
       </div>
     </div>

--- a/src/pages/AddPickUpGame/index.js
+++ b/src/pages/AddPickUpGame/index.js
@@ -2,11 +2,10 @@ import { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { toast } from 'react-toastify'
-import { v4 as uuid } from 'uuid';
 
 import Icon from '../../components/Icon';
 import List from '../../components/List';
-import { getTeamsApi, getPlayersApi } from '../../firebase/api';
+import { getTeamsApi, getPlayersApi, addGameApi } from '../../firebase/api';
 import { addTeams } from '../../redux/teams-reducer';
 import { addPlayers } from '../../redux/players-reducer';
 import { addGameToCache, removeGameFromCache, addNewGame } from '../../redux/games-reducer';
@@ -19,6 +18,7 @@ export default function AddPickUpGame() {
   const dispatch = useDispatch();
 
   const [getTeamsLoading, setGetTeamsLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
 
   const user = useSelector(state => state.user);
   const teams = useSelector(state => state.teams);
@@ -63,7 +63,7 @@ export default function AddPickUpGame() {
     dispatch(addGameToCache({ teamA: team.id }))
   };
 
-  const onCreateNewPickUpGame = () => {
+  const onCreateNewPickUpGame = async () => {
     if (!games.editing.teamA || !games.editing.teamB) {
       toast.error('Select 2 teams before starting your pick-up game', {
         position: 'top-center'
@@ -85,23 +85,29 @@ export default function AddPickUpGame() {
       return false;
     }
 
-    const newGame = {
-      id: uuid(),
-      teamAId: teamA.id,
-      teamBId: teamB.id,
-      createdBy: user.id,
-      createdOn: new Date().getTime(),
-      actions: [],
-      type: 'pick-up',
-      teamAScore: 0,
-      teamBScore: 0,
-      notSaved: true,
-      stats: {},
-    };
-
-    dispatch(addNewGame(newGame));
-    trackGameStarted('pick-up');
-    navigate(`/games/pick-up-game/${newGame.id}`);
+    setSaving(true);
+    try {
+      const gameData = {
+        teamAId: teamA.id,
+        teamBId: teamB.id,
+        createdBy: user.email,
+        createdOn: new Date().getTime(),
+        actions: [],
+        type: 'pick-up',
+        teamAScore: 0,
+        teamBScore: 0,
+        stats: {},
+      };
+      const savedGame = await addGameApi(gameData);
+      dispatch(addNewGame(savedGame));
+      trackGameStarted('pick-up');
+      navigate(`/games/pick-up-game/${savedGame.id}`);
+    } catch (err) {
+      console.error('CREATE GAME ERR:', err);
+      toast.error('Failed to create game. Please try again.', { position: 'top-center' });
+    } finally {
+      setSaving(false);
+    }
   };
 
   const teamA = teams.byId[games.editing.teamA];
@@ -195,13 +201,14 @@ export default function AddPickUpGame() {
       <div className="mt-6">
         <button
           type="button"
-          className="w-full sm:w-auto inline-flex items-center rounded-md bg-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-orange-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600"
+          disabled={saving}
+          className="w-full sm:w-auto inline-flex items-center rounded-md bg-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-orange-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600 disabled:opacity-60 disabled:cursor-not-allowed"
           onClick={onCreateNewPickUpGame}
         >
-          {false && (
+          {saving && (
             <Icon type="loader" className="h-5 w-5 mr-2" spinnerColor={colors.orange600} spinnerBackgroundColor={colors.grey300} />
           )}
-          Create new pick-up game
+          {saving ? 'Creating...' : 'Create new pick-up game'}
         </button>
       </div>
     </div>

--- a/src/pages/TournamentDetail/index.js
+++ b/src/pages/TournamentDetail/index.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import { v4 as uuid } from 'uuid';
 import { getTournamentByIdApi, addGameApi, updateTournamentApi } from '../../firebase/api';
 import { updateTournament, addGameToTournament } from '../../redux/tournaments-reducer';
 import { addNewGame } from '../../redux/games-reducer';
@@ -60,7 +59,6 @@ const TournamentDetail = () => {
 
       // Create a new game
       const gameData = {
-        id: uuid(),
         teamAId: teamA.id,
         teamBId: teamB.id,
         createdBy: user.email,
@@ -69,7 +67,6 @@ const TournamentDetail = () => {
         type: 'pick-up',
         teamAScore: 0,
         teamBScore: 0,
-        notSaved: true,
         stats: {},
         tournamentId: tournamentId,
         tournamentRound: round,

--- a/src/redux/games-reducer.test.js
+++ b/src/redux/games-reducer.test.js
@@ -1,0 +1,306 @@
+import gamesReducer, {
+  addNewGame,
+  addMadeShot,
+  addAttemptedShot,
+  addRebound,
+  addAssist,
+  addFoul,
+  addDrillCompletion,
+  addDrillAttempt,
+  undoLastAction,
+  updateLastActions,
+  endGame,
+} from './games-reducer';
+
+const makePickUpGame = (overrides = {}) => ({
+  id: 'game1',
+  type: 'pick-up',
+  teamAId: 'teamA',
+  teamBId: 'teamB',
+  teamAScore: 0,
+  teamBScore: 0,
+  actions: [],
+  stats: {},
+  finished: false,
+  ...overrides,
+});
+
+const makeDrill = (overrides = {}) => ({
+  id: 'drill1',
+  type: 'drill',
+  playerIds: ['p1', 'p2'],
+  actions: [],
+  stats: {},
+  finished: false,
+  ...overrides,
+});
+
+const makeState = (game) => ({
+  byId: { [game.id]: game },
+  allIds: [game.id],
+  editing: { teamA: null, teamB: null },
+});
+
+describe('addNewGame', () => {
+  it('adds a game to state', () => {
+    const game = makePickUpGame();
+    const state = gamesReducer(undefined, addNewGame(game));
+    expect(state.byId['game1']).toEqual(game);
+    expect(state.allIds).toContain('game1');
+  });
+});
+
+describe('pickup game scoring', () => {
+  const teamId = 'teamA';
+  const playerId = 'p1';
+  const gameId = 'game1';
+
+  const gameWith = (points, made = true) => {
+    const game = makePickUpGame();
+    const state = makeState(game);
+    const action = made
+      ? addMadeShot({ gameId, teamId, playerId, points })
+      : addAttemptedShot({ gameId, teamId, playerId, points });
+    return gamesReducer(state, action);
+  };
+
+  it('records a made free throw (1 point)', () => {
+    const state = gameWith(1);
+    expect(state.byId.game1.stats.teamA.p1.freeThrows).toBe(1);
+    expect(state.byId.game1.teamAScore).toBe(1);
+  });
+
+  it('records a made 2-pointer', () => {
+    const state = gameWith(2);
+    expect(state.byId.game1.stats.teamA.p1.twos).toBe(1);
+    expect(state.byId.game1.teamAScore).toBe(2);
+  });
+
+  it('records a made 3-pointer', () => {
+    const state = gameWith(3);
+    expect(state.byId.game1.stats.teamA.p1.threes).toBe(1);
+    expect(state.byId.game1.teamAScore).toBe(3);
+  });
+
+  it('records a missed free throw (attempted only)', () => {
+    const state = gameWith(1, false);
+    expect(state.byId.game1.stats.teamA.p1.attemptedFreeThrows).toBe(1);
+    expect(state.byId.game1.teamAScore).toBe(0);
+  });
+
+  it('records a missed 2-pointer (attempted only)', () => {
+    const state = gameWith(2, false);
+    expect(state.byId.game1.stats.teamA.p1.attemptedTwos).toBe(1);
+    expect(state.byId.game1.teamAScore).toBe(0);
+  });
+
+  it('records a missed 3-pointer (attempted only)', () => {
+    const state = gameWith(3, false);
+    expect(state.byId.game1.stats.teamA.p1.attemptedThrees).toBe(1);
+    expect(state.byId.game1.teamAScore).toBe(0);
+  });
+
+  it('records an offensive rebound', () => {
+    const game = makePickUpGame();
+    const state = gamesReducer(makeState(game), addRebound({ gameId, teamId, playerId, reboundType: 'offensive' }));
+    expect(state.byId.game1.stats.teamA.p1.offensiveRebounds).toBe(1);
+  });
+
+  it('records a defensive rebound', () => {
+    const game = makePickUpGame();
+    const state = gamesReducer(makeState(game), addRebound({ gameId, teamId, playerId, reboundType: 'defensive' }));
+    expect(state.byId.game1.stats.teamA.p1.defensiveRebounds).toBe(1);
+  });
+
+  it('records an assist', () => {
+    const game = makePickUpGame();
+    const state = gamesReducer(makeState(game), addAssist({ gameId, teamId, playerId }));
+    expect(state.byId.game1.stats.teamA.p1.assists).toBe(1);
+  });
+
+  it('records a foul', () => {
+    const game = makePickUpGame();
+    const state = gamesReducer(makeState(game), addFoul({ gameId, teamId, playerId }));
+    expect(state.byId.game1.stats.teamA.p1.fouls).toBe(1);
+  });
+
+  it('accumulates score from multiple made shots', () => {
+    let state = makeState(makePickUpGame());
+    state = gamesReducer(state, addMadeShot({ gameId, teamId, playerId, points: 2 }));
+    state = gamesReducer(state, addMadeShot({ gameId, teamId, playerId, points: 3 }));
+    expect(state.byId.game1.teamAScore).toBe(5);
+    expect(state.byId.game1.stats.teamA.p1.twos).toBe(1);
+    expect(state.byId.game1.stats.teamA.p1.threes).toBe(1);
+  });
+
+  it('does not affect teamBScore when teamA scores', () => {
+    const state = gameWith(3);
+    expect(state.byId.game1.teamBScore).toBe(0);
+  });
+});
+
+describe('undo', () => {
+  const teamId = 'teamA';
+  const playerId = 'p1';
+  const gameId = 'game1';
+
+  // Convention: undoLastAction receives the CURRENT actions list (with the action
+  // to undo still at the end). The reducer reads the last item and reverses it.
+  // The caller is responsible for trimming the list after dispatch.
+  const doUndo = (state, actionRecord) =>
+    gamesReducer(state, undoLastAction({ gameId, actions: [actionRecord] }));
+
+  it('undoes a made 2-pointer', () => {
+    let state = makeState(makePickUpGame());
+    state = gamesReducer(state, addMadeShot({ gameId, teamId, playerId, points: 2 }));
+    expect(state.byId.game1.teamAScore).toBe(2);
+    state = doUndo(state, { action: 'addMadeShot', gameId, teamId, playerId, points: 2 });
+    expect(state.byId.game1.teamAScore).toBe(0);
+    expect(state.byId.game1.stats.teamA.p1.twos).toBe(0);
+  });
+
+  it('undoes a made 3-pointer', () => {
+    let state = makeState(makePickUpGame());
+    state = gamesReducer(state, addMadeShot({ gameId, teamId, playerId, points: 3 }));
+    state = doUndo(state, { action: 'addMadeShot', gameId, teamId, playerId, points: 3 });
+    expect(state.byId.game1.teamAScore).toBe(0);
+    expect(state.byId.game1.stats.teamA.p1.threes).toBe(0);
+  });
+
+  it('undoes a made free throw', () => {
+    let state = makeState(makePickUpGame());
+    state = gamesReducer(state, addMadeShot({ gameId, teamId, playerId, points: 1 }));
+    state = doUndo(state, { action: 'addMadeShot', gameId, teamId, playerId, points: 1 });
+    expect(state.byId.game1.teamAScore).toBe(0);
+    expect(state.byId.game1.stats.teamA.p1.freeThrows).toBe(0);
+  });
+
+  it('undoes a missed 3-pointer', () => {
+    let state = makeState(makePickUpGame());
+    state = gamesReducer(state, addAttemptedShot({ gameId, teamId, playerId, points: 3 }));
+    state = doUndo(state, { action: 'addAttemptedShot', gameId, teamId, playerId, points: 3 });
+    expect(state.byId.game1.stats.teamA.p1.attemptedThrees).toBe(0);
+  });
+
+  it('undoes a missed 2-pointer', () => {
+    let state = makeState(makePickUpGame());
+    state = gamesReducer(state, addAttemptedShot({ gameId, teamId, playerId, points: 2 }));
+    state = doUndo(state, { action: 'addAttemptedShot', gameId, teamId, playerId, points: 2 });
+    expect(state.byId.game1.stats.teamA.p1.attemptedTwos).toBe(0);
+  });
+
+  it('undoes a missed free throw', () => {
+    let state = makeState(makePickUpGame());
+    state = gamesReducer(state, addAttemptedShot({ gameId, teamId, playerId, points: 1 }));
+    state = doUndo(state, { action: 'addAttemptedShot', gameId, teamId, playerId, points: 1 });
+    expect(state.byId.game1.stats.teamA.p1.attemptedFreeThrows).toBe(0);
+  });
+
+  it('undoes an offensive rebound', () => {
+    let state = makeState(makePickUpGame());
+    state = gamesReducer(state, addRebound({ gameId, teamId, playerId, reboundType: 'offensive' }));
+    state = doUndo(state, { action: 'addRebound', gameId, teamId, playerId, reboundType: 'offensive' });
+    expect(state.byId.game1.stats.teamA.p1.offensiveRebounds).toBe(0);
+  });
+
+  it('undoes an assist', () => {
+    let state = makeState(makePickUpGame());
+    state = gamesReducer(state, addAssist({ gameId, teamId, playerId }));
+    state = doUndo(state, { action: 'addAssist', gameId, teamId, playerId });
+    expect(state.byId.game1.stats.teamA.p1.assists).toBe(0);
+  });
+
+  it('undoes a foul', () => {
+    let state = makeState(makePickUpGame());
+    state = gamesReducer(state, addFoul({ gameId, teamId, playerId }));
+    state = doUndo(state, { action: 'addFoul', gameId, teamId, playerId });
+    expect(state.byId.game1.stats.teamA.p1.fouls).toBe(0);
+  });
+
+  it('does nothing when action list is empty', () => {
+    const game = makePickUpGame();
+    let state = makeState(game);
+    const before = JSON.stringify(state.byId.game1);
+    state = gamesReducer(state, undoLastAction({ gameId, actions: [] }));
+    expect(JSON.stringify(state.byId.game1.stats)).toBe('{}');
+    expect(state.byId.game1.teamAScore).toBe(0);
+  });
+
+  it('score does not go negative if undo is called without a prior made shot', () => {
+    const game = makePickUpGame();
+    let state = makeState(game);
+    state = gamesReducer(state, addMadeShot({ gameId, teamId, playerId, points: 2 }));
+    // Undo once (valid)
+    state = doUndo(state, { action: 'addMadeShot', gameId, teamId, playerId, points: 2 });
+    expect(state.byId.game1.teamAScore).toBe(0);
+    // State is now back to 0 — no crash on empty undo
+    state = gamesReducer(state, undoLastAction({ gameId, actions: [] }));
+    expect(state.byId.game1.teamAScore).toBe(0);
+  });
+});
+
+describe('drill tracking', () => {
+  const gameId = 'drill1';
+  const playerId = 'p1';
+
+  it('increments both attempts and completions on completion', () => {
+    const drill = makeDrill();
+    let state = makeState(drill);
+    state = gamesReducer(state, addDrillCompletion({ gameId, playerId }));
+    expect(state.byId.drill1.stats.p1.attempts).toBe(1);
+    expect(state.byId.drill1.stats.p1.completions).toBe(1);
+  });
+
+  it('increments only attempts on a miss', () => {
+    const drill = makeDrill();
+    let state = makeState(drill);
+    state = gamesReducer(state, addDrillAttempt({ gameId, playerId }));
+    expect(state.byId.drill1.stats.p1.attempts).toBe(1);
+    // completions must remain at initialDrillStats value (0), not increment
+    expect(state.byId.drill1.stats.p1.completions).toBe(0);
+  });
+
+  it('initializes stats on the first action', () => {
+    const drill = makeDrill();
+    let state = makeState(drill);
+    state = gamesReducer(state, addDrillCompletion({ gameId, playerId }));
+    expect(state.byId.drill1.stats.p1).toMatchObject({ attempts: 1, completions: 1 });
+  });
+
+  it('undoes a drill completion', () => {
+    const drill = makeDrill();
+    let state = makeState(drill);
+    state = gamesReducer(state, addDrillCompletion({ gameId, playerId }));
+    state = gamesReducer(state, undoLastAction({ gameId, actions: [{ action: 'addDrillCompletion', gameId, playerId }] }));
+    expect(state.byId.drill1.stats.p1.attempts).toBe(0);
+    expect(state.byId.drill1.stats.p1.completions).toBe(0);
+  });
+
+  it('undoes a drill attempt', () => {
+    const drill = makeDrill();
+    let state = makeState(drill);
+    state = gamesReducer(state, addDrillAttempt({ gameId, playerId }));
+    state = gamesReducer(state, undoLastAction({ gameId, actions: [{ action: 'addDrillAttempt', gameId, playerId }] }));
+    expect(state.byId.drill1.stats.p1.attempts).toBe(0);
+  });
+
+  it('calculates success rate correctly', () => {
+    const drill = makeDrill();
+    let state = makeState(drill);
+    state = gamesReducer(state, addDrillCompletion({ gameId, playerId }));
+    state = gamesReducer(state, addDrillAttempt({ gameId, playerId }));
+    const { attempts, completions } = state.byId.drill1.stats.p1;
+    const rate = ((completions / attempts) * 100).toFixed(1);
+    expect(rate).toBe('50.0');
+  });
+});
+
+describe('endGame', () => {
+  it('marks the game as finished', () => {
+    const game = makePickUpGame();
+    let state = makeState(game);
+    state = gamesReducer(state, endGame('game1'));
+    expect(state.byId.game1.finished).toBe(true);
+    expect(state.byId.game1.endedAt).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Addresses all 4 release-blocking GitHub issues before production deploy:

- **Closes #35** — Fix game and drill Firestore persistence: games and drills now save to Firestore immediately when created, so `game.id` in Redux always matches the Firestore document ID. Previously, `uuid()` was passed as a data field and overwrote `newGameRef.id` in `addGameApi`'s return value, causing `batch.update` to target a non-existent document when ending the game.
- **Closes #36** — Standardize `createdBy`: `AddPickUpGame` and `AddDrill` were setting `createdBy: user.id` (which is `undefined`). Now both use `user.email`, consistent with players, teams, and tournaments. Same bug fixed in `ManualScoreModal` and `TournamentDetail`.
- **Closes #31** — Tighten Firestore security rules: all collections now enforce ownership on `get`, `list`, and `create` (not just `update`/`delete`). Users collection restricted to own-email-only access.
- **Closes #32** — Add regression tests: `games-reducer.test.js` covers scoring, missed shots, rebounds, assists, fouls, undo behavior, drill tracking, and end-game. CI workflow now runs `npm test` before build.

## Key code changes

- `addGameApi`: strips any incoming `id`/`notSaved` fields before writing to Firestore; returns `id: newGameRef.id` last so it always wins
- `pushStatsToFirebase`: upgraded from `batch.update` to `batch.set({merge:true})` on the game doc as a safety net
- `AddPickUpGame` and `AddDrill`: now `async`, call `addGameApi` at creation time, show loading state on button, display toast error if Firestore write fails

## Test plan

- [ ] Log in as test user, create 2 teams with players, start a pick-up game — verify Firestore `game` collection has the document with matching ID
- [ ] Record shots, rebounds, assist, foul — verify live stats update
- [ ] End game — verify `finished: true` and `endedAt` in Firestore
- [ ] Start a drill, record completions and misses, end drill — verify Firestore persisted
- [ ] Log in as User B — verify User A's games/players/teams are not readable
- [ ] Run `npm test -- --watchAll=false` and verify all reducer tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)