### PR TITLE
Redesign game UI to v2 dark court aesthetic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "dotenv": "^16.4.5",
         "firebase": "^9.19.1",
         "framer-motion": "^10.10.0",
-        "posthog-js": "^1.372.5",
+        "posthog-js": "^1.373.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-easy-crop": "^5.1.0",
@@ -5086,18 +5086,18 @@
       }
     },
     "node_modules/@posthog/core": {
-      "version": "1.27.9",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.27.9.tgz",
-      "integrity": "sha512-7FFWWYWvRFxQqDXYzv8klCjk0Pox1IpuPr61eeOCBsKkmt6xvvHwH0jc3ObvwDXZj2NSAWg+V9N2E2F1ul2CRQ==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.1.tgz",
+      "integrity": "sha512-q+/t/DZALr50YTE0dFgfGSS9EgwcyAlqsn+JS61wLkwdcDM5yu/YTDM8oMKmJupsyjSZlVkDuHZAMd4ab7AxzQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "1.372.5"
+        "@posthog/types": "1.373.4"
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.372.5",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.5.tgz",
-      "integrity": "sha512-6sYOISiHjfr50FNlFcd8Zw/zCDJzxRCdC7aZzwTCvJABEOLWf41kcsiozi2c3q1cNXYL018X7DAGkUukrNLVIw==",
+      "version": "1.373.4",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.373.4.tgz",
+      "integrity": "sha512-n+0AbGRYYsbi+CQXQi2rF1lwTSyASlaogcw4YSkzB5KeMa4Y6nhNb7+TTnu9aVor+BycsQYCa2OsBrMMbaTekw==",
       "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
@@ -16866,9 +16866,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/posthog-js": {
-      "version": "1.372.5",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.5.tgz",
-      "integrity": "sha512-0Wq4yRTX8rg2/SOTo3T/0tt2EIE0usBDJKxWPY6eRTGxWAajNmPWZwK4vREn2ANZGdPhUHQ+hg4kLEUdQnzs/Q==",
+      "version": "1.373.4",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.373.4.tgz",
+      "integrity": "sha512-6DueUS5KOGZlKsQlelLURmtp9PA52rdCxt/IvuoYKAErlkh2LczogMopUIpeqbwfOnGDQEf8gmDh4z/IFeU4CQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -16876,8 +16876,8 @@
         "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
         "@opentelemetry/resources": "^2.2.0",
         "@opentelemetry/sdk-logs": "^0.208.0",
-        "@posthog/core": "1.27.9",
-        "@posthog/types": "1.372.5",
+        "@posthog/core": "1.29.1",
+        "@posthog/types": "1.373.4",
         "core-js": "^3.38.1",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dotenv": "^16.4.5",
     "firebase": "^9.19.1",
     "framer-motion": "^10.10.0",
-    "posthog-js": "^1.372.5",
+    "posthog-js": "^1.373.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-easy-crop": "^5.1.0",

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
     <link rel="manifest" href="./manifest.json" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Audiowide&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Barlow+Condensed:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
 
     <title>HoopTrackr – Track Your Game Like a Pro</title>
 

--- a/src/components/GameControls.js
+++ b/src/components/GameControls.js
@@ -14,6 +14,7 @@ import {
 } from "../redux/games-reducer";
 import PlayerSelection from "./PlayerSelection";
 import GameResult from "./GameResults";
+import { pushStatsToFirebase } from "../firebase/api";
 
 /* ── helpers ── */
 const getPlayerPts = (s) =>
@@ -530,7 +531,12 @@ const GameControls = ({ currentGameId, currentPlayer, selectedPlayers, onPlayerS
     setLastActions((prev) => prev.slice(0, -1)); // remove newest (at end)
   };
 
-  const handleEndGame = () => {
+  const handleEndGame = async () => {
+    try {
+      await pushStatsToFirebase(currentGame, teamA, teamB);
+    } catch (err) {
+      console.error("Error persisting final stats:", err);
+    }
     dispatch(endGame(currentGame.id));
     navigate("/games");
   };

--- a/src/components/GameControls.js
+++ b/src/components/GameControls.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { v4 as uuid } from "uuid";
 import { useSelector, useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
@@ -8,599 +8,855 @@ import {
   addRebound,
   addAssist,
   addFoul,
-  addDrillAttempt,
-  addDrillCompletion,
   updateLastActions,
   undoLastAction,
   endGame,
 } from "../redux/games-reducer";
-import "../css/main.css";
 import PlayerSelection from "./PlayerSelection";
 import GameResult from "./GameResults";
-import { buttonStyles } from '../utils/buttonStyles';
 
+/* ── helpers ── */
+const getPlayerPts = (s) =>
+  s ? (s.threes || 0) * 3 + (s.twos || 0) * 2 + (s.freeThrows || 0) : 0;
+const getPlayerFgm = (s) => s ? (s.threes || 0) + (s.twos || 0) : 0;
+const getPlayerFga = (s) =>
+  s
+    ? (s.threes || 0) + (s.twos || 0) + (s.attemptedThrees || 0) + (s.attemptedTwos || 0)
+    : 0;
+const getPlayerReb = (s) =>
+  s ? (s.offensiveRebounds || 0) + (s.defensiveRebounds || 0) : 0;
+
+/* ── Float Particles ── */
+function FloatParticles({ items }) {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        pointerEvents: "none",
+        overflow: "hidden",
+        zIndex: 9999,
+      }}
+    >
+      {items.map((p) => (
+        <div
+          key={p.id}
+          style={{
+            position: "absolute",
+            left: `${p.x}%`,
+            top: `${p.y}%`,
+            fontFamily: "var(--ff-display)",
+            fontWeight: 800,
+            fontSize: p.pts >= 3 ? "2.4rem" : "1.9rem",
+            color:
+              p.pts < 0
+                ? "#f87171"
+                : p.pts >= 3
+                ? "var(--ht-gold)"
+                : "#fff",
+            textShadow:
+              p.pts >= 3
+                ? "0 0 24px rgba(251,191,36,.9)"
+                : "0 0 16px rgba(246,78,7,.7)",
+            animation: "ht-score-float 0.95s ease-out forwards",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {p.pts < 0 ? "MISS" : p.pts >= 3 ? `+${p.pts} 🔥` : `+${p.pts}`}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ── Leaderboard strip ── */
+function LeaderboardStrip({ allPlayers, allStats, teamAId, teamBId }) {
+  const sorted = allPlayers
+    .map((p) => {
+      const teamId = p.teamId;
+      const s = allStats?.[teamId]?.[p.id];
+      return { ...p, pts: getPlayerPts(s) };
+    })
+    .filter((p) => p.pts > 0)
+    .sort((a, b) => b.pts - a.pts)
+    .slice(0, 6);
+
+  if (!sorted.length) return null;
+
+  return (
+    <div style={{ flexShrink: 0 }}>
+      <div
+        style={{
+          fontSize: "0.58rem",
+          color: "var(--ht-muted)",
+          letterSpacing: "0.12em",
+          marginBottom: 5,
+          fontWeight: 700,
+          fontFamily: "var(--ff-body)",
+        }}
+      >
+        🏆 LEADERS
+      </div>
+      <div
+        style={{
+          display: "flex",
+          gap: 6,
+          overflowX: "auto",
+          paddingBottom: 2,
+          WebkitOverflowScrolling: "touch",
+        }}
+      >
+        {sorted.map((p, i) => (
+          <div
+            key={p.id}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 5,
+              background: "var(--ht-card)",
+              borderRadius: 20,
+              padding: "4px 9px 4px 5px",
+              flexShrink: 0,
+              border: `1px solid ${
+                i === 0 ? "rgba(251,191,36,.3)" : "rgba(255,255,255,.06)"
+              }`,
+            }}
+          >
+            <span
+              style={{
+                width: 17,
+                height: 17,
+                borderRadius: "50%",
+                background:
+                  i === 0
+                    ? "var(--ht-gold)"
+                    : i === 1
+                    ? "rgba(255,255,255,.15)"
+                    : "var(--ht-card2)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: "0.5rem",
+                color: i === 0 ? "#000" : "var(--ht-muted)",
+                fontWeight: 800,
+                flexShrink: 0,
+              }}
+            >
+              {i + 1}
+            </span>
+            <span
+              style={{
+                fontSize: "0.73rem",
+                fontWeight: 700,
+                whiteSpace: "nowrap",
+                color: "var(--ht-text)",
+                fontFamily: "var(--ff-body)",
+              }}
+            >
+              {p.name}
+            </span>
+            <span
+              style={{
+                fontFamily: "var(--ff-display)",
+                fontSize: "0.7rem",
+                color: i === 0 ? "var(--ht-gold)" : "var(--ht-orange)",
+                marginLeft: 1,
+              }}
+            >
+              {p.pts}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── Player Sheet (bottom sheet) ── */
+function PlayerSheet({ players, selected, color, teamName, allStats, teamId, onSelect, onClose }) {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.8)",
+        backdropFilter: "blur(10px)",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "flex-end",
+        zIndex: 200,
+        animation: "ht-fade-in 0.15s ease",
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: "var(--ht-card)",
+          borderRadius: "20px 20px 0 0",
+          padding: "20px 20px 32px",
+          animation: "ht-slide-in 0.22s ease",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: 18,
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontFamily: "var(--ff-display)",
+                fontSize: "0.9rem",
+                color,
+                letterSpacing: "0.08em",
+              }}
+            >
+              SELECT PLAYER
+            </div>
+            <div
+              style={{
+                fontSize: "0.72rem",
+                color: "var(--ht-muted)",
+                marginTop: 2,
+                fontFamily: "var(--ff-body)",
+              }}
+            >
+              {teamName}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              width: 30,
+              height: 30,
+              borderRadius: "50%",
+              background: "rgba(255,255,255,.08)",
+              border: "none",
+              color: "var(--ht-muted)",
+              cursor: "pointer",
+              fontSize: "1rem",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            ×
+          </button>
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, 1fr)",
+            gap: 10,
+          }}
+        >
+          {players.map((p) => {
+            const on = selected?.id === p.id;
+            const s = allStats?.[teamId]?.[p.id];
+            const pts = getPlayerPts(s);
+            return (
+              <button
+                key={p.id}
+                onClick={() => onSelect(p)}
+                style={{
+                  padding: "14px 8px",
+                  background: on ? color + "25" : "var(--ht-card2)",
+                  border: `2px solid ${on ? color : "rgba(255,255,255,.06)"}`,
+                  borderRadius: 12,
+                  cursor: "pointer",
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: 5,
+                  transition: "all 0.1s",
+                  boxShadow: on ? `0 0 14px ${color}35` : "none",
+                }}
+              >
+                <div
+                  style={{
+                    fontFamily: "var(--ff-display)",
+                    fontSize: "1.25rem",
+                    color: on ? color : "var(--ht-text)",
+                  }}
+                >
+                  #{p.number}
+                </div>
+                <div
+                  style={{
+                    fontSize: "0.75rem",
+                    color: on ? "var(--ht-text)" : "var(--ht-muted)",
+                    fontWeight: 700,
+                    textAlign: "center",
+                    fontFamily: "var(--ff-body)",
+                  }}
+                >
+                  {p.name}
+                </div>
+                {pts > 0 && (
+                  <div
+                    style={{
+                      fontSize: "0.65rem",
+                      color: on ? color : "var(--ht-dim)",
+                      fontWeight: 700,
+                      fontFamily: "var(--ff-body)",
+                    }}
+                  >
+                    {pts}pts
+                  </div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── End Game modal ── */
+function EndModal({ onConfirm, onCancel, label = "Game" }) {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.82)",
+        backdropFilter: "blur(10px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 24,
+        zIndex: 300,
+      }}
+    >
+      <div
+        style={{
+          background: "var(--ht-card)",
+          borderRadius: 18,
+          padding: "28px 24px",
+          width: "100%",
+          maxWidth: 360,
+          textAlign: "center",
+          animation: "ht-slide-up 0.2s ease",
+          border: "1px solid rgba(255,255,255,.07)",
+        }}
+      >
+        <div style={{ fontSize: "2.2rem", marginBottom: 12 }}>🏁</div>
+        <div
+          style={{
+            fontFamily: "var(--ff-display)",
+            fontSize: "1.1rem",
+            marginBottom: 8,
+            color: "var(--ht-text)",
+          }}
+        >
+          End {label}?
+        </div>
+        <div
+          style={{
+            color: "var(--ht-muted)",
+            fontSize: "0.84rem",
+            marginBottom: 24,
+            lineHeight: 1.6,
+            fontFamily: "var(--ff-body)",
+          }}
+        >
+          Stats will be saved and you'll get a shareable game card!
+        </div>
+        <div style={{ display: "flex", gap: 10 }}>
+          <button
+            onClick={onCancel}
+            className="ht-btn-ghost"
+            style={{ flex: 1, padding: "12px", fontSize: "0.88rem" }}
+          >
+            Keep Playing
+          </button>
+          <button
+            onClick={onConfirm}
+            style={{
+              flex: 1,
+              padding: "12px",
+              background: "var(--ht-orange)",
+              border: "none",
+              borderRadius: 10,
+              color: "#fff",
+              fontSize: "0.88rem",
+              fontWeight: 700,
+              cursor: "pointer",
+              fontFamily: "var(--ff-body)",
+              boxShadow: "0 4px 16px rgba(246,78,7,.4)",
+            }}
+          >
+            End & Share 🏆
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════
+   MAIN COMPONENT
+═══════════════════════════════════════ */
 const GameControls = ({ currentGameId, currentPlayer, selectedPlayers, onPlayerSelect }) => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const currentGame = useSelector((state) => state.games.byId[currentGameId]);
   const teamA = useSelector((state) => state.teams.byId[currentGame.teamAId]);
   const teamB = useSelector((state) => state.teams.byId[currentGame.teamBId]);
   const players = useSelector((state) => state.players);
-  const allPlayers = useMemo(() => {
-    return players.allIds
-      .map((playerId) => players.byId[playerId])
-      .filter(player => player !== undefined);
-  }, [players.allIds, players.byId]);
-  const teamAPlayers = useMemo(() => {
-    return (teamA?.players || [])
-      .map((playerId) => players.byId[playerId])
-      .filter(player => player !== undefined);
-  }, [teamA?.players, players.byId]);
-  const teamBPlayers = useMemo(() => {
-    return (teamB?.players || [])
-      .map((playerId) => players.byId[playerId])
-      .filter(player => player !== undefined);
-  }, [teamB?.players, players.byId]);
-  const mode = currentGame.type;
+  const allStats = currentGame.stats || {};
 
-  const [selectedTeam, setSelectedTeam] = useState(
-    mode === "pick-up" ? "teamA" : null
+  const teamAPlayers = useMemo(
+    () =>
+      (teamA?.players || [])
+        .map((id) => players.byId[id])
+        .filter(Boolean)
+        .map((p) => ({ ...p, teamId: teamA?.id })),
+    [teamA, players.byId]
   );
-  const [selectedPlayer, setSelectedPlayer] = useState(currentPlayer);
-  const [showPlayerSelection, setShowPlayerSelection] = useState(false);
+  const teamBPlayers = useMemo(
+    () =>
+      (teamB?.players || [])
+        .map((id) => players.byId[id])
+        .filter(Boolean)
+        .map((p) => ({ ...p, teamId: teamB?.id })),
+    [teamB, players.byId]
+  );
+  const allPlayers = useMemo(() => [...teamAPlayers, ...teamBPlayers], [teamAPlayers, teamBPlayers]);
+
+  /* ── local state ── */
+  const [activeTeam, setActiveTeam] = useState("teamA");
+  const [selectedPlayer, setSelectedPlayer] = useState(currentPlayer || null);
+  const [shotPts, setShotPts] = useState(2);
+  const [showSelect, setShowSelect] = useState(false);
+  const [showEnd, setShowEnd] = useState(false);
   const [showGameResult, setShowGameResult] = useState(false);
-  const [undoLoading, setUndoLoading] = useState(false);
-  const [madeLoading, setMadeLoading] = useState(false);
-  const [attemptLoading, setAttemptLoading] = useState(false);
-  const [reboundLoading, setReboundLoading] = useState(false);
-  const [assistLoading, setAssistLoading] = useState(false);
-  const [foulLoading, setFoulLoading] = useState(false);
-  const [playerOptionsMap, setPlayerOptionsMap] = useState({
-    teamA: [],
-    teamB: [],
-  });
-  const navigate = useNavigate();
-
   const [lastActions, setLastActions] = useState(currentGame.actions || []);
-  const [showAllActions, setShowAllActions] = useState(false);
+  const [floats, setFloats] = useState([]);
+  const [madeKey, setMadeKey] = useState(0);
+  const [streaks, setStreaks] = useState({});
 
-  // Calculate drill stats
-  const drillStats = useMemo(() => {
-    if (mode === "drill" && selectedPlayer) {
-      return currentGame.stats[selectedPlayer.id] || { attempts: 0, completions: 0 };
-    }
-    return { attempts: 0, completions: 0 };
-  }, [mode, selectedPlayer, currentGame.stats]);
+  const team = activeTeam === "teamA" ? teamA : teamB;
+  const teamPlayers = activeTeam === "teamA" ? teamAPlayers : teamBPlayers;
+  const teamColor = activeTeam === "teamA" ? "var(--ht-orange)" : "var(--ht-cyan)";
+  const teamId = activeTeam === "teamA" ? teamA?.id : teamB?.id;
 
-  const successRate = useMemo(() => {
-    if (drillStats.attempts === 0) return 0;
-    return ((drillStats.completions / drillStats.attempts) * 100).toFixed(1);
-  }, [drillStats]);
+  /* current player's display stats */
+  const pStats = selectedPlayer
+    ? allStats?.[teamId]?.[selectedPlayer.id]
+    : null;
+  const pPts = getPlayerPts(pStats);
+  const pFgm = getPlayerFgm(pStats);
+  const pFga = getPlayerFga(pStats);
+  const pFgPct = pFga > 0 ? Math.round((pFgm / pFga) * 100) : null;
+  const streak = streaks[selectedPlayer?.id] || 0;
 
-  const [showEndGameConfirmation, setShowEndGameConfirmation] = useState(false);
-
+  /* ── sync actions to redux ── */
   useEffect(() => {
-    if (mode === "drill") {
-      setPlayerOptionsMap({
-        teamA: selectedPlayers || [],
-        teamB: selectedPlayers || [],
-      });
-    } else if (mode === "pick-up") {
-      setPlayerOptionsMap({
-        teamA: teamAPlayers,
-        teamB: teamBPlayers,
-      });
-    }
-  }, [mode, teamA, teamB, selectedPlayers]);
+    dispatch(updateLastActions({ gameId: currentGame.id, actions: lastActions }));
+  }, [lastActions, dispatch, currentGame.id]);
 
-  useEffect(() => {
-    dispatch(
-      updateLastActions({ gameId: currentGame.id, actions: lastActions })
-    );
-  }, [lastActions, dispatch]);
+  const addFloat = useCallback((pts) => {
+    const id = Date.now() + Math.random();
+    const x = 38 + Math.random() * 24;
+    const y = 30 + Math.random() * 20;
+    setFloats((prev) => [...prev, { id, pts, x, y }]);
+    setTimeout(() => setFloats((prev) => prev.filter((f) => f.id !== id)), 1000);
+  }, []);
 
-  const handleTeamChange = (teamValue) => {
-    setSelectedTeam(teamValue);
+  const pushAction = useCallback((label, type, pts = 0) => {
+    setLastActions((prev) => [...prev.slice(-8), { id: uuid(), label, type, pts }]);
+  }, []);
+
+  /* ── handlers ── */
+  const handleTeamChange = (teamKey) => {
+    setActiveTeam(teamKey);
     setSelectedPlayer(null);
   };
 
   const handlePlayerSelect = (player) => {
-    console.log('PP: ', player, currentPlayer)
     setSelectedPlayer(player);
-    setShowPlayerSelection(false);
-    if (onPlayerSelect) {
-      onPlayerSelect(player);
-    }
+    setShowSelect(false);
+    if (onPlayerSelect) onPlayerSelect(player);
   };
 
-  const handleAttempt = async (points) => {
-    if (!selectedPlayer) {
-      setShowPlayerSelection(true);
-    } else {
-      dispatch(
-        addAttemptedShot({
-          gameId: currentGame.id,
-          teamId: mode === "pick-up" ? (selectedTeam === "teamA" ? teamA.id : teamB.id) : selectedPlayer.id,
-          playerId: selectedPlayer.id,
-          gameMode: mode,
-          points,
-        })
-      );
-      setLastActions((prev) => [
-        ...prev,
-        {
-          id: uuid(),
-          action: "addAttemptedShot",
-          gameId: currentGame.id,
-          teamId: mode === "pick-up" ? (selectedTeam === "teamA" ? teamA.id : teamB.id) : selectedPlayer.id,
-          playerId: selectedPlayer.id,
-          points,
-          playerNumber: selectedPlayer.number,
-          gameMode: mode,
-        },
-      ]);
-    }
+  const handleMade = () => {
+    if (!selectedPlayer) { setShowSelect(true); return; }
+    const tid = teamId;
+    dispatch(addMadeShot({ gameId: currentGame.id, teamId: tid, playerId: selectedPlayer.id, points: shotPts }));
+    const entry = { id: uuid(), action: "addMadeShot", gameId: currentGame.id, teamId: tid, playerId: selectedPlayer.id, points: shotPts, playerNumber: selectedPlayer.number, label: `${selectedPlayer.name} +${shotPts}`, type: "made", pts: shotPts };
+    setLastActions((prev) => [...prev.slice(-8), entry]); // oldest-first, newest at end
+    setStreaks((prev) => ({ ...prev, [selectedPlayer.id]: (prev[selectedPlayer.id] || 0) + 1 }));
+    setMadeKey((k) => k + 1);
+    addFloat(shotPts);
   };
 
-  const handleMade = async (points) => {
-    if (!selectedPlayer) {
-      setShowPlayerSelection(true);
-    } else {
-      dispatch(
-        addMadeShot({
-          gameId: currentGame.id,
-          teamId: mode === "pick-up" ? (selectedTeam === "teamA" ? teamA.id : teamB.id) : selectedPlayer.id,
-          playerId: selectedPlayer.id,
-          gameMode: mode,
-          points,
-        })
-      );
-      setLastActions((prev) => [
-        ...prev,
-        {
-          id: uuid(),
-          action: "addMadeShot",
-          gameId: currentGame.id,
-          teamId: mode === "pick-up" ? (selectedTeam === "teamA" ? teamA.id : teamB.id) : selectedPlayer.id,
-          playerId: selectedPlayer.id,
-          points,
-          playerNumber: selectedPlayer.number,
-          gameMode: mode,
-        },
-      ]);
-    }
+  const handleMiss = () => {
+    if (!selectedPlayer) { setShowSelect(true); return; }
+    const tid = teamId;
+    dispatch(addAttemptedShot({ gameId: currentGame.id, teamId: tid, playerId: selectedPlayer.id, points: shotPts }));
+    const entry = { id: uuid(), action: "addAttemptedShot", gameId: currentGame.id, teamId: tid, playerId: selectedPlayer.id, points: shotPts, playerNumber: selectedPlayer.number, label: `${selectedPlayer.name} MISS`, type: "miss", pts: 0 };
+    setLastActions((prev) => [...prev.slice(-8), entry]);
+    setStreaks((prev) => ({ ...prev, [selectedPlayer.id]: 0 }));
+    addFloat(-1);
   };
 
-  const handleRebound = async (type) => {
-    if (!selectedPlayer) {
-      setShowPlayerSelection(true);
-    } else {
-      dispatch(
-        addRebound({
-          gameId: currentGame.id,
-          teamId: selectedTeam === "teamA" ? teamA.id : teamB.id,
-          playerId: selectedPlayer.id,
-          gameMode: mode,
-          reboundType: type,
-        })
-      );
-      setLastActions((prev) => [
-        ...prev,
-        {
-          id: uuid(),
-          action: "addRebound",
-          gameId: currentGame.id,
-          teamId: selectedTeam === "teamA" ? teamA.id : teamB.id,
-          playerId: selectedPlayer.id,
-          reboundType: type,
-          playerNumber: selectedPlayer.number,
-          gameMode: mode,
-        },
-      ]);
-    }
+  const handleAssist = () => {
+    if (!selectedPlayer) { setShowSelect(true); return; }
+    dispatch(addAssist({ gameId: currentGame.id, teamId, playerId: selectedPlayer.id }));
+    pushAction(`${selectedPlayer.name} AST`, "ast");
   };
 
-  const handleAssist = async () => {
-    if (!selectedPlayer) {
-      setShowPlayerSelection(true);
-    } else {
-      dispatch(
-        addAssist({
-          gameId: currentGame.id,
-          teamId: selectedTeam === "teamA" ? teamA.id : teamB.id,
-          playerId: selectedPlayer.id,
-          gameMode: mode,
-        })
-      );
-      setLastActions((prev) => [
-        ...prev,
-        {
-          id: uuid(),
-          action: "addAssist",
-          gameId: currentGame.id,
-          teamId: selectedTeam === "teamA" ? teamA.id : teamB.id,
-          playerId: selectedPlayer.id,
-          playerNumber: selectedPlayer.number,
-          gameMode: mode,
-        },
-      ]);
-    }
+  const handleRebound = () => {
+    if (!selectedPlayer) { setShowSelect(true); return; }
+    dispatch(addRebound({ gameId: currentGame.id, teamId, playerId: selectedPlayer.id, reboundType: "offensive" }));
+    pushAction(`${selectedPlayer.name} REB`, "reb");
   };
 
-  const handleFoul = async () => {
-    if (!selectedPlayer) {
-      setShowPlayerSelection(true);
-    } else {
-      dispatch(
-        addFoul({
-          gameId: currentGame.id,
-          teamId: selectedTeam === "teamA" ? teamA.id : teamB.id,
-          playerId: selectedPlayer.id,
-          gameMode: mode,
-        })
-      );
-      setLastActions((prev) => [
-        ...prev,
-        {
-          id: uuid(),
-          action: "addFoul",
-          gameId: currentGame.id,
-          teamId: selectedTeam === "teamA" ? teamA.id : teamB.id,
-          playerId: selectedPlayer.id,
-          playerNumber: selectedPlayer.number,
-          gameMode: mode,
-        },
-      ]);
-    }
+  const handleFoul = () => {
+    if (!selectedPlayer) { setShowSelect(true); return; }
+    dispatch(addFoul({ gameId: currentGame.id, teamId, playerId: selectedPlayer.id }));
+    pushAction(`FOUL #${selectedPlayer.number}`, "foul");
   };
 
-  const handleDrillCompletion = () => {
-    if (!selectedPlayer) {
-      setShowPlayerSelection(true);
-    } else {
-      dispatch(
-        addDrillCompletion({
-          gameId: currentGame.id,
-          playerId: selectedPlayer.id,
-        })
-      );
-      setLastActions((prev) => [
-        ...prev,
-        {
-          id: uuid(),
-          action: "addDrillCompletion",
-          gameId: currentGame.id,
-          playerId: selectedPlayer.id,
-          playerNumber: selectedPlayer.number,
-          gameMode: mode,
-        },
-      ]);
-    }
+  const handleUndo = () => {
+    if (!lastActions.length) return;
+    dispatch(undoLastAction({ gameId: currentGame.id, actions: lastActions })); // reducer uses [last]
+    setLastActions((prev) => prev.slice(0, -1)); // remove newest (at end)
   };
 
-  const handleDrillAttempt = () => {
-    if (!selectedPlayer) {
-      setShowPlayerSelection(true);
-    } else {
-      dispatch(
-        addDrillAttempt({
-          gameId: currentGame.id,
-          playerId: selectedPlayer.id,
-        })
-      );
-      setLastActions((prev) => [
-        ...prev,
-        {
-          id: uuid(),
-          action: "addDrillAttempt",
-          gameId: currentGame.id,
-          playerId: selectedPlayer.id,
-          playerNumber: selectedPlayer.number,
-          gameMode: mode,
-        },
-      ]);
-    }
+  const handleEndGame = () => {
+    dispatch(endGame(currentGame.id));
+    navigate("/games");
   };
 
-  const handleShowGameResult = () => {
-    setShowGameResult(true);
-  };
-
-  const handleConfirmEndGame = () => {
-    setShowEndGameConfirmation(false);
-    setShowGameResult(true);
-    handleEndGame();
-  };
-
-  const handleCancelEndGame = () => {
-    setShowEndGameConfirmation(false);
-  };
-
-  const handleBackClick = () => {
-    setShowGameResult(false);
-  };
-
-  const handleDeleteLastAction = async () => {
-    dispatch(undoLastAction({ gameId: currentGame.id, actions: lastActions }));
-    setLastActions((prevLastActions) => {
-      return prevLastActions.slice(0, -1);
-    });
-  };
-
-  const handleEndGame = async () => {
-    try {
-      // For freemium version, we only update the Redux store
-      dispatch(endGame(currentGame.id));
-      navigate('/games');
-    } catch (err) {
-      console.error('Error ending game:', err);
-    }
-  };
-
-  const displayedActions = showAllActions
-    ? lastActions.slice(-10)
-    : lastActions.length > 0
-      ? [lastActions[lastActions.length - 1]]
-      : [];
+  const actionColor = { made: "var(--ht-orange)", miss: "var(--ht-miss)", ast: "var(--ht-cyan)", reb: "#4ade80", foul: "#fbbf24" };
 
   return (
-    <div className="Controls">
-      {/* Team Selection */}
-      {mode === "pick-up" && (
-        <div className="flex justify-around py-4">
-          <button
-            className={`py-4 px-8 md:py-5 md:px-10 text-lg md:text-xl font-bold rounded-lg transition-transform duration-200 transform ${
-              selectedTeam === "teamA"
-                ? "bg-[#f64e07] text-white scale-110"
-                : "bg-gray-300 text-gray-700"
-            }`}
-            onClick={() => handleTeamChange("teamA")}
-          >
-            {teamA?.name || "Team A"}
-          </button>
+    <>
+      <FloatParticles items={floats} />
 
-          <button
-            className={`py-4 px-8 md:py-5 md:px-10 text-lg md:text-xl font-bold rounded-lg transition-transform duration-200 transform ${
-              selectedTeam === "teamB"
-                ? "bg-[#f64e07] text-white scale-110"
-                : "bg-gray-300 text-gray-700"
-            }`}
-            onClick={() => handleTeamChange("teamB")}
-          >
-            {teamB?.name || "Team B"}
-          </button>
-        </div>
-      )}
+      {/* Team toggle */}
+      <div style={{ padding: "10px 16px 0", display: "flex", gap: 8, flexShrink: 0 }}>
+        {["teamA", "teamB"].map((tk) => {
+          const t = tk === "teamA" ? teamA : teamB;
+          const on = activeTeam === tk;
+          const c = tk === "teamA" ? "var(--ht-orange)" : "var(--ht-cyan)";
+          return (
+            <button
+              key={tk}
+              onClick={() => handleTeamChange(tk)}
+              style={{
+                flex: 1,
+                padding: "9px",
+                borderRadius: 10,
+                border: `2px solid ${on ? c : "rgba(255,255,255,.07)"}`,
+                background: on ? c + "1e" : "transparent",
+                color: on ? c : "var(--ht-muted)",
+                fontFamily: "var(--ff-body)",
+                fontSize: "0.92rem",
+                fontWeight: 700,
+                cursor: "pointer",
+                letterSpacing: "0.06em",
+                transition: "all 0.15s",
+                boxShadow: on ? `0 0 14px ${c}35` : "none",
+              }}
+            >
+              {t?.name || (tk === "teamA" ? "Team A" : "Team B")}
+            </button>
+          );
+        })}
+      </div>
 
-      {/* Player Selection */}
-      {showPlayerSelection ? (
-        <PlayerSelection
-          team={mode === "pick-up" ? selectedTeam : null}
-          players={mode === "drill" ? selectedPlayers : playerOptionsMap[selectedTeam]}
-          onSelect={handlePlayerSelect}
-          onClose={setShowPlayerSelection}
-        />
-      ) : (
-        <div className="flex flex-col items-center space-y-4">
-          <button
-            disabled={mode === "pick-up" && !!currentPlayer}
-            className="relative w-full sm:w-auto py-2 px-4 md:py-4 md:px-8 text-base md:text-xl font-bold text-white bg-[#0aa6d6]
-                      rounded-lg shadow-lg hover:shadow-2xl transition-transform transform hover:scale-105 hover:rotate-2 duration-200
-                      focus:outline-none focus:ring-4 focus:ring-[#0aa6d6]"
-            onClick={() => setShowPlayerSelection(true)}
-          >
-            <span className="absolute inset-0 bg-[#0a355e] opacity-75 blur-lg rounded-lg animate-pulse"></span>
-            <span className="relative z-10">
-              {selectedPlayer
-                ? `#${selectedPlayer.number} - ${selectedPlayer.name}`
-                : "Select Player"}
-            </span>
-          </button>
-
-          {mode === "drill" ? (
-            <div className="flex flex-col items-center justify-center space-y-6 p-4 w-full">
-              <h2 className="text-xl font-bold text-white">
-                Drill Mode: {selectedPlayer?.name}
-              </h2>
-
-              <div className="flex space-x-4">
-                <button 
-                  className={`${buttonStyles.madeShot} py-4 px-8 text-xl`} 
-                  onClick={handleDrillCompletion}
-                >
-                  Made 
-                </button>
-                <button 
-                  className={`${buttonStyles.missedShot} py-4 px-8 text-xl`} 
-                  onClick={handleDrillAttempt}
-                >
-                  Miss 
-                </button>
+      {/* Player chip */}
+      <div style={{ padding: "10px 16px 0", flexShrink: 0 }}>
+        <button
+          onClick={() => setShowSelect(true)}
+          style={{
+            width: "100%",
+            padding: "11px 14px",
+            background: selectedPlayer ? "var(--ht-card2)" : "rgba(246,78,7,.08)",
+            border: `1.5px solid ${selectedPlayer ? "rgba(255,255,255,.09)" : "var(--ht-orange)"}`,
+            borderRadius: 12,
+            color: "var(--ht-text)",
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            cursor: "pointer",
+            transition: "all 0.15s",
+          }}
+        >
+          {selectedPlayer ? (
+            <>
+              <div
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: "50%",
+                  flexShrink: 0,
+                  background: activeTeam === "teamA" ? "var(--ht-orange-dim)" : "var(--ht-cyan-dim)",
+                  border: `2px solid ${teamColor}`,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontFamily: "var(--ff-display)",
+                  fontSize: "0.72rem",
+                  color: teamColor,
+                }}
+              >
+                {selectedPlayer.number}
               </div>
-
-              <div className="flex space-x-4">
-                <button className={buttonStyles.undo} onClick={handleDeleteLastAction}>Undo</button>
-                <button 
-                  className="bg-blue-600 hover:bg-blue-700 text-white font-bold px-6 py-3 rounded-lg" 
-                  onClick={handleShowGameResult}
-                >
-                  Game Results
-                </button>
+              <div style={{ flex: 1, textAlign: "left" }}>
+                <div style={{ fontSize: "0.95rem", fontWeight: 700, fontFamily: "var(--ff-body)" }}>
+                  {selectedPlayer.name}
+                </div>
+                <div style={{ fontSize: "0.68rem", color: "var(--ht-muted)", marginTop: 1, fontFamily: "var(--ff-body)" }}>
+                  {pFga > 0
+                    ? `${pPts}pts · ${pFgm}/${pFga} FG · ${pFgPct}%`
+                    : "Tap to change player"}
+                </div>
               </div>
-            </div>
+              {streak >= 2 && (
+                <div style={{ fontSize: "1.1rem", animation: "ht-fire-glow 1.4s ease-in-out infinite" }}>
+                  {streak >= 4 ? "🔥🔥" : "🔥"}
+                </div>
+              )}
+              <div style={{ color: "var(--ht-muted)", fontSize: "0.8rem" }}>›</div>
+            </>
           ) : (
             <>
-              {/* Shot Controls Grid */}
-              <div className="grid grid-cols-3 gap-1 w-full px-2">
-                {/* Free Throw Column */}
-                <div className="flex flex-col items-center space-y-2">
-                  <h3 className="text-white font-semibold">Free Throw</h3>
-                  <button 
-                    className={`${buttonStyles.madeShot} w-full py-4 px-20 text-xl`} 
-                    onClick={() => handleMade(1)}
-                    disabled={madeLoading === 1}
-                  >
-                    {madeLoading === 1 ? "Loading..." : "+1"}
-                  </button>
-                  <button 
-                    className={`${buttonStyles.missedShot} w-full py-4 px-8 text-xl`} 
-                    onClick={() => handleAttempt(1)}
-                    disabled={attemptLoading === 1}
-                  >
-                    {attemptLoading === 1 ? "Loading..." : "Miss"}
-                  </button>
-                </div>
-
-                {/* 2 Points Column */}
-                <div className="flex flex-col items-center space-y-2">
-                  <h3 className="text-white font-semibold">2 Points</h3>
-                  <button 
-                    className={`${buttonStyles.madeShot} w-full py-4 px-20 text-xl`} 
-                    onClick={() => handleMade(2)}
-                    disabled={madeLoading === 2}
-                  >
-                    {madeLoading === 2 ? "Loading..." : "+2"}
-                  </button>
-                  <button 
-                    className={`${buttonStyles.missedShot} w-full py-4 px-8 text-xl`} 
-                    onClick={() => handleAttempt(2)}
-                    disabled={attemptLoading === 2}
-                  >
-                    {attemptLoading === 2 ? "Loading..." : "Miss"}
-                  </button>
-                </div>
-
-                {/* 3 Points Column */}
-                <div className="flex flex-col items-center space-y-2">
-                  <h3 className="text-white font-semibold">3 Points</h3>
-                  <button 
-                    className={`${buttonStyles.madeShot} w-full py-4 px-20 text-xl`} 
-                    onClick={() => handleMade(3)}
-                    disabled={madeLoading === 3}
-                  >
-                    {madeLoading === 3 ? "Loading..." : "+3"}
-                  </button>
-                  <button 
-                    className={`${buttonStyles.missedShot} w-full py-4 px-8 text-xl`} 
-                    onClick={() => handleAttempt(3)}
-                    disabled={attemptLoading === 3}
-                  >
-                    {attemptLoading === 3 ? "Loading..." : "Miss"}
-                  </button>
-                </div>
-              </div>
-
-              {/* Other Controls */}
-              <div className="grid grid-cols-2 gap-4 w-full">
-                <button className={buttonStyles.assist} onClick={handleAssist}>
-                  Assist
-                </button>
-                <button className={buttonStyles.rebound} onClick={() => handleRebound("offensive")}>
-                  Rebound
-                </button>
-                <button className={buttonStyles.foul} onClick={handleFoul}>
-                  Foul
-                </button>
-                <button className={buttonStyles.undo} onClick={handleDeleteLastAction}>
-                  Undo
-                </button>
-              </div>
-
-              {/* Game Results Button */}
-              <button 
-                className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded-lg shadow-lg transition-colors duration-200"
-                onClick={handleShowGameResult}
+              <div
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: "50%",
+                  background: "var(--ht-orange-dim)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: "1.1rem",
+                  flexShrink: 0,
+                }}
               >
-                Game Results
-              </button>
+                👆
+              </div>
+              <div style={{ flex: 1, textAlign: "left", fontSize: "0.9rem", color: "var(--ht-orange)", fontWeight: 600, fontFamily: "var(--ff-body)" }}>
+                Select a Player
+              </div>
+              <div style={{ color: "var(--ht-orange)", fontSize: "0.8rem" }}>›</div>
             </>
           )}
-        </div>
-      )}
+        </button>
+      </div>
 
-      {/* Last Actions Table */}
-      {mode === "pick-up" && (
-        <div className="py-4">
-          <h2 className="text-lg sm:text-xl font-bold text-orange-600 mb-4 text-center">
-            Last Actions
-          </h2>
-          <div className="overflow-x-auto">
-            <table className="min-w-full table-auto bg-gray-100 border border-gray-300 rounded-lg shadow-sm">
-              <thead>
-                <tr className="bg-gray-200 text-gray-800">
-                  <th className="py-3 px-6 text-left text-sm font-semibold border-b border-gray-300">
-                    Action
-                  </th>
-                  <th className="py-3 px-6 text-left text-sm font-semibold border-b border-gray-300">
-                    Points
-                  </th>
-                  <th className="py-3 px-6 text-left text-sm font-semibold border-b border-gray-300">
-                    Player #
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {lastActions.slice(-10).map((action, index) => (
-                  <tr
-                    key={action.id}
-                    className={`${
-                      index % 2 === 0 ? "bg-white" : "bg-gray-50"
-                    } hover:bg-gray-200 transition-colors`}
-                  >
-                    <td className="py-3 px-6 text-sm text-gray-900 border-b border-gray-300">
-                      {action.action}
-                    </td>
-                    <td className="py-3 px-6 text-sm text-green-600 font-semibold border-b border-gray-300">
-                      {action.points}
-                    </td>
-                    <td className="py-3 px-6 text-sm text-orange-500 font-semibold border-b border-gray-300">
-                      #{action.playerNumber}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+      {/* Controls area */}
+      <div
+        style={{
+          flex: 1,
+          padding: "10px 16px 16px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 8,
+          minHeight: 0,
+          overflowY: "auto",
+        }}
+      >
+        {/* Shot type pills */}
+        <div
+          style={{
+            display: "flex",
+            background: "var(--ht-card)",
+            borderRadius: 10,
+            padding: 3,
+            gap: 2,
+            flexShrink: 0,
+          }}
+        >
+          {[
+            { pts: 1, label: "1PT · FT" },
+            { pts: 2, label: "2PT" },
+            { pts: 3, label: "3PT · ARC" },
+          ].map(({ pts, label }) => (
+            <button
+              key={pts}
+              onClick={() => setShotPts(pts)}
+              style={{
+                flex: 1,
+                padding: "7px 4px",
+                borderRadius: 8,
+                border: "none",
+                background: shotPts === pts ? "var(--ht-orange)" : "transparent",
+                color: shotPts === pts ? "#fff" : "var(--ht-muted)",
+                fontFamily: "var(--ff-body)",
+                fontSize: "0.78rem",
+                fontWeight: 700,
+                cursor: "pointer",
+                transition: "all 0.15s",
+                letterSpacing: "0.06em",
+                boxShadow: shotPts === pts ? "0 2px 10px rgba(246,78,7,.4)" : "none",
+              }}
+            >
+              {label}
+            </button>
+          ))}
         </div>
-      )}
 
-      {/* End Game Confirmation Modal */}
-      {showEndGameConfirmation && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
-            <h2 className="text-2xl font-bold mb-4 text-center">
-              End {mode === "drill" ? "Drill" : "Game"}?
-            </h2>
-            <p className="text-gray-600 mb-6 text-center">
-              Are you sure you want to end this {mode === "drill" ? "drill" : "game"}? 
-              This action cannot be undone.
-            </p>
-            <div className="flex justify-center space-x-4">
-              <button
-                onClick={handleCancelEndGame}
-                className="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-800 rounded-md"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleConfirmEndGame}
-                className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md"
-              >
-                End {mode === "drill" ? "Drill" : "Game"}
-              </button>
+        {/* MADE button */}
+        <button
+          key={madeKey}
+          className="ht-btn-made flash"
+          onClick={handleMade}
+          style={{ height: 88, fontSize: "1.55rem", flexShrink: 0 }}
+        >
+          <span style={{ position: "relative", zIndex: 1 }}>✓ MADE</span>
+          <span style={{ position: "relative", zIndex: 1, fontSize: "0.72rem", opacity: 0.85, letterSpacing: "0.1em" }}>
+            +{shotPts} {shotPts === 1 ? "FREE THROW" : shotPts === 2 ? "2-POINTER" : "3-POINTER"}
+          </span>
+        </button>
+
+        {/* MISS button */}
+        <button
+          className="ht-btn-miss"
+          onClick={handleMiss}
+          style={{ height: 56, fontSize: "0.95rem", flexShrink: 0 }}
+        >
+          ✕&nbsp;&nbsp;MISS
+        </button>
+
+        {/* Stat buttons */}
+        <div style={{ display: "flex", gap: 7, flexShrink: 0 }}>
+          {[
+            { label: "🤝 ASSIST", fn: handleAssist },
+            { label: "💪 REBOUND", fn: handleRebound },
+            { label: "⚠ FOUL", fn: handleFoul },
+          ].map(({ label, fn }) => (
+            <button
+              key={label}
+              className="ht-btn-stat"
+              onClick={fn}
+              style={{ height: 48, fontSize: "0.73rem", letterSpacing: "0.04em" }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {/* Leaderboard strip */}
+        <LeaderboardStrip allPlayers={allPlayers} allStats={allStats} teamAId={teamA?.id} teamBId={teamB?.id} />
+
+        {/* Action feed */}
+        <div
+          style={{
+            flex: 1,
+            background: "var(--ht-card)",
+            borderRadius: 10,
+            padding: "10px 12px",
+            overflow: "hidden",
+            minHeight: 44,
+          }}
+        >
+          {lastActions.length === 0 ? (
+            <div style={{ color: "var(--ht-dim)", fontSize: "0.75rem", textAlign: "center", paddingTop: 4, fontFamily: "var(--ff-body)" }}>
+              Shot log will appear here
             </div>
-          </div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+              {[...lastActions].reverse().slice(0, 4).map((a, i) => (
+                <div key={a.id} style={{ display: "flex", alignItems: "center", gap: 8, opacity: Math.max(0.2, 1 - i * 0.18) }}>
+                  <div
+                    style={{
+                      width: 5,
+                      height: 5,
+                      borderRadius: "50%",
+                      background: actionColor[a.type] || "var(--ht-muted)",
+                      flexShrink: 0,
+                    }}
+                  />
+                  <div
+                    style={{
+                      flex: 1,
+                      fontSize: "0.78rem",
+                      color: i === 0 ? "var(--ht-text)" : "var(--ht-muted)",
+                      fontWeight: i === 0 ? 600 : 400,
+                      fontFamily: "var(--ff-body)",
+                    }}
+                  >
+                    {a.label || a.action}
+                  </div>
+                  {a.pts > 0 && (
+                    <div style={{ fontFamily: "var(--ff-display)", fontSize: "0.78rem", color: "var(--ht-orange)" }}>
+                      +{a.pts}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
-      )}
 
-      {/* Game Result Modal */}
+        {/* Bottom row: Undo + End Game */}
+        <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
+          <button
+            className="ht-btn-ghost"
+            onClick={handleUndo}
+            style={{ flex: 1, height: 42, fontSize: "0.75rem", letterSpacing: "0.06em" }}
+          >
+            ↩ UNDO
+          </button>
+          <button
+            onClick={() => setShowEnd(true)}
+            style={{
+              flex: 2,
+              height: 42,
+              background: "var(--ht-orange-dim)",
+              border: "1.5px solid rgba(246,78,7,.3)",
+              borderRadius: "var(--ht-rs)",
+              color: "var(--ht-orange)",
+              fontFamily: "var(--ff-body)",
+              fontSize: "0.83rem",
+              fontWeight: 700,
+              cursor: "pointer",
+              letterSpacing: "0.07em",
+            }}
+          >
+            END GAME 🏁
+          </button>
+        </div>
+      </div>
+
+      {/* Overlays */}
+      {showSelect && (
+        <PlayerSheet
+          players={teamPlayers}
+          selected={selectedPlayer}
+          color={teamColor}
+          teamName={team?.name}
+          allStats={allStats}
+          teamId={teamId}
+          onSelect={handlePlayerSelect}
+          onClose={() => setShowSelect(false)}
+        />
+      )}
+      {showEnd && (
+        <EndModal
+          label="Game"
+          onConfirm={() => { setShowEnd(false); setShowGameResult(true); handleEndGame(); }}
+          onCancel={() => setShowEnd(false)}
+        />
+      )}
       {showGameResult && (
-        <div className="game-result-overlay fixed inset-0 flex justify-center items-center bg-black bg-opacity-80 z-50">
-          <div className="game-result-container w-full max-w-4xl rounded-lg shadow-2xl bg-white text-center relative overflow-y-auto max-h-screen">
-            <GameResult game={currentGame} onBackClick={handleBackClick} />
+        <div style={{ position: "fixed", inset: 0, display: "flex", justifyContent: "center", alignItems: "center", background: "rgba(0,0,0,0.9)", zIndex: 500 }}>
+          <div style={{ width: "100%", maxWidth: 480, maxHeight: "100vh", overflowY: "auto" }}>
+            <GameResult game={currentGame} onBackClick={() => setShowGameResult(false)} />
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/components/GameResults.js
+++ b/src/components/GameResults.js
@@ -1,169 +1,651 @@
-import React, { useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import { motion } from 'framer-motion';
-import { useNavigate } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import { initialStats, endGame } from '../redux/games-reducer';
-import { pushStatsToFirebase } from '../firebase/api';
-import { trackGameFinished } from '../analytics';
+import React, { useState, useMemo, useRef } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import { initialStats, endGame } from "../redux/games-reducer";
+import { pushStatsToFirebase } from "../firebase/api";
+import { trackGameFinished } from "../analytics";
 
+/* ── helpers ── */
+const getPts = (s) => s ? (s.threes || 0) * 3 + (s.twos || 0) * 2 + (s.freeThrows || 0) : 0;
+const getReb = (s) => s ? (s.offensiveRebounds || 0) + (s.defensiveRebounds || 0) : 0;
+const getAst = (s) => s?.assists || 0;
+const getFouls = (s) => s?.fouls || 0;
+const getFgm = (s) => s ? (s.threes || 0) + (s.twos || 0) : 0;
+const getFga = (s) => s ? (s.threes || 0) + (s.twos || 0) + (s.attemptedThrees || 0) + (s.attemptedTwos || 0) : 0;
+const getFgPct = (s) => { const a = getFga(s); return a > 0 ? Math.round((getFgm(s) / a) * 100) : 0; };
+const getTpm = (s) => s?.threes || 0;
+const getTpa = (s) => s ? (s.threes || 0) + (s.attemptedThrees || 0) : 0;
+const getTpPct = (s) => { const a = getTpa(s); return a > 0 ? Math.round((getTpm(s) / a) * 100) : 0; };
+const getFtm = (s) => s?.freeThrows || 0;
+const getFta = (s) => s ? (s.freeThrows || 0) + (s.attemptedFreeThrows || 0) : 0;
+const getFtPct = (s) => { const a = getFta(s); return a > 0 ? Math.round((getFtm(s) / a) * 100) : 0; };
+
+/* ── Confetti ── */
+function Confetti() {
+  const pieces = useMemo(
+    () =>
+      Array.from({ length: 70 }, (_, i) => ({
+        id: i,
+        left: Math.random() * 100,
+        delay: Math.random() * 2.8,
+        dur: 2.2 + Math.random() * 2.4,
+        color: ["#f64e07", "#0aa6d6", "#fbbf24", "#fff", "#4ade80", "#e879f9"][Math.floor(Math.random() * 6)],
+        w: 5 + Math.random() * 7,
+        h: Math.random() > 0.5 ? 5 + Math.random() * 7 : 3 + Math.random() * 4,
+        round: Math.random() > 0.4,
+      })),
+    []
+  );
+  return (
+    <div style={{ position: "fixed", inset: 0, pointerEvents: "none", overflow: "hidden", zIndex: 9998 }}>
+      {pieces.map((p) => (
+        <div
+          key={p.id}
+          style={{
+            position: "absolute",
+            top: -20,
+            left: `${p.left}%`,
+            width: p.w,
+            height: p.h,
+            background: p.color,
+            borderRadius: p.round ? "50%" : "2px",
+            animation: `ht-confetti-fall ${p.dur}s ${p.delay}s ease-in both`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/* ── Shooting bar ── */
+function ShootBar({ label, made, att, pct, color }) {
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+        <span style={{ fontSize: "0.72rem", color: "var(--ht-muted)", letterSpacing: "0.08em", fontWeight: 700, fontFamily: "var(--ff-body)" }}>
+          {label}
+        </span>
+        <span style={{ fontSize: "0.72rem", color: "var(--ht-text)", fontWeight: 700, fontFamily: "var(--ff-body)" }}>
+          {made}/{att} <span style={{ color, marginLeft: 4 }}>{pct}%</span>
+        </span>
+      </div>
+      <div style={{ height: 6, background: "rgba(255,255,255,.06)", borderRadius: 3, overflow: "hidden" }}>
+        <div style={{
+          height: "100%", width: `${pct}%`, background: color, borderRadius: 3,
+          transition: "width 0.8s ease", boxShadow: `0 0 8px ${color}60`,
+        }} />
+      </div>
+    </div>
+  );
+}
+
+/* ── Player Profile Modal ── */
+function PlayerProfileModal({ player, stats, teamColor, teamName, onClose }) {
+  const s = stats || {};
+  return (
+    <div
+      style={{
+        position: "fixed", inset: 0, background: "rgba(0,0,0,0.82)", backdropFilter: "blur(12px)",
+        display: "flex", flexDirection: "column", justifyContent: "flex-end", zIndex: 600,
+        animation: "ht-fade-in 0.15s ease",
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: "var(--ht-card)", borderRadius: "20px 20px 0 0",
+          padding: "20px 20px 36px", animation: "ht-slide-in 0.2s ease",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 18 }}>
+          <div style={{
+            width: 52, height: 52, borderRadius: "50%", background: teamColor + "22",
+            border: `2px solid ${teamColor}`, display: "flex", alignItems: "center", justifyContent: "center",
+            fontFamily: "var(--ff-display)", fontSize: "0.9rem", color: teamColor, flexShrink: 0,
+          }}>
+            #{player.number}
+          </div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: "1.2rem", fontWeight: 800, fontFamily: "var(--ff-body)" }}>{player.name}</div>
+            <div style={{ fontSize: "0.72rem", color: "var(--ht-muted)", marginTop: 1, fontFamily: "var(--ff-body)" }}>{teamName}</div>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              width: 30, height: 30, borderRadius: "50%", background: "rgba(255,255,255,.08)",
+              border: "none", color: "var(--ht-muted)", cursor: "pointer", fontSize: "1rem",
+              display: "flex", alignItems: "center", justifyContent: "center",
+            }}
+          >×</button>
+        </div>
+
+        {/* Big stat line */}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 8, marginBottom: 18 }}>
+          {[
+            { l: "PTS", v: getPts(s), c: "var(--ht-orange)" },
+            { l: "REB", v: getReb(s), c: "var(--ht-cyan)" },
+            { l: "AST", v: getAst(s), c: "var(--ht-green)" },
+            { l: "PF", v: getFouls(s), c: "var(--ht-gold)" },
+          ].map(({ l, v, c }) => (
+            <div key={l} style={{ background: "var(--ht-card2)", borderRadius: 10, padding: "10px 6px", textAlign: "center" }}>
+              <div style={{ fontFamily: "var(--ff-display)", fontSize: "1.5rem", color: c, lineHeight: 1 }}>{v}</div>
+              <div style={{ fontSize: "0.58rem", color: "var(--ht-muted)", letterSpacing: "0.1em", marginTop: 3, fontFamily: "var(--ff-body)" }}>{l}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Shooting */}
+        <div style={{ fontSize: "0.62rem", color: "var(--ht-muted)", letterSpacing: "0.12em", fontWeight: 700, marginBottom: 10, fontFamily: "var(--ff-body)" }}>
+          SHOOTING EFFICIENCY
+        </div>
+        <ShootBar label="FG (2PT)" made={getFgm(s) - getTpm(s)} att={getFga(s) - getTpa(s)} pct={getFga(s) - getTpa(s) > 0 ? Math.round(((getFgm(s) - getTpm(s)) / (getFga(s) - getTpa(s))) * 100) : 0} color="var(--ht-orange)" />
+        <ShootBar label="3-POINTER" made={getTpm(s)} att={getTpa(s)} pct={getTpPct(s)} color="var(--ht-gold)" />
+        <ShootBar label="FREE THROW" made={getFtm(s)} att={getFta(s)} pct={getFtPct(s)} color="var(--ht-cyan)" />
+        {getFga(s) === 0 && getFta(s) === 0 && (
+          <div style={{ fontSize: "0.78rem", color: "var(--ht-dim)", textAlign: "center", padding: "8px 0", fontFamily: "var(--ff-body)" }}>
+            No shooting data yet
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════
+   MAIN COMPONENT
+═══════════════════════════════════════ */
 const GameResults = ({ game, onBackClick }) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const isDrillMode = game.type === 'drill';
-  const { teamAId, teamAScore, teamBId, teamBScore } = game;
-  const [showEndGameConfirmation, setShowEndGameConfirmation] = useState(false);
+  const teams = useSelector((state) => state.teams);
+  const players = useSelector((state) => state.players);
+  const isDrill = game.type === "drill";
+
+  const teamA = teams.byId[game.teamAId];
+  const teamB = teams.byId[game.teamBId];
+
+  const [statsTeam, setStatsTeam] = useState("teamA");
+  const [profilePlayer, setProfilePlayer] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const [shareToast, setShareToast] = useState("");
   const [endingGame, setEndingGame] = useState(false);
+  const [showEndConfirm, setShowEndConfirm] = useState(false);
+  const shareCardRef = useRef(null);
 
-  const teams = useSelector(state => state.teams);
-  const players = useSelector(state => state.players);
-  const teamA = teams.byId[teamAId];
-  const teamB = teams.byId[teamBId];
+  /* ── MVP ── */
+  const mvp = useMemo(() => {
+    if (isDrill) return null;
+    const allPlayerIds = [
+      ...(teamA?.players || []),
+      ...(teamB?.players || []),
+    ];
+    let best = null, bestPts = -1;
+    allPlayerIds.forEach((pid) => {
+      const teamId = teamA?.players?.includes(pid) ? teamA.id : teamB?.id;
+      const s = game.stats?.[teamId]?.[pid];
+      const pts = getPts(s);
+      if (pts > bestPts) { bestPts = pts; best = { player: players.byId[pid], stats: s, teamId }; }
+    });
+    return best?.player ? best : null;
+  }, [isDrill, teamA, teamB, game.stats, players.byId]);
 
-  const drillStats = isDrillMode && game.stats;
-  const drillPlayer = players.byId[game.playerId];
+  const winner = useMemo(() => {
+    if (isDrill) return null;
+    const diff = game.teamAScore - game.teamBScore;
+    if (diff > 0) return teamA;
+    if (diff < 0) return teamB;
+    return null;
+  }, [isDrill, game.teamAScore, game.teamBScore, teamA, teamB]);
+
+  const toast_ = (msg) => { setShareToast(msg); setTimeout(() => setShareToast(""), 2400); };
+
+  const handleShare = async (platform) => {
+    const mvpLine = mvp ? ` | MVP: ${mvp.player.name} (${getPts(mvp.stats)}pts)` : "";
+    const text = isDrill
+      ? `🎯 Drill complete! #HoopTrackr`
+      : `${teamA?.name} ${game.teamAScore} – ${game.teamBScore} ${teamB?.name}${mvpLine}  🏀 #HoopTrackr`;
+
+    if (platform === "twitter") window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`);
+    else if (platform === "whatsapp") window.open(`https://wa.me/?text=${encodeURIComponent(text)}`);
+    else if (platform === "copy") {
+      navigator.clipboard?.writeText("https://hooptrackr.app").catch(() => {});
+      setCopied(true); setTimeout(() => setCopied(false), 2200);
+      toast_("Link copied!");
+    }
+  };
 
   const handleEndGame = async () => {
     setEndingGame(true);
     try {
       await pushStatsToFirebase(game, teamA, teamB);
-      trackGameFinished(game.type || 'pick-up');
+      trackGameFinished(game.type || "pick-up");
       dispatch(endGame(game.id));
-      navigate('/games');
+      navigate("/games");
     } catch (err) {
-      console.error('Error ending game:', err);
-      toast.error('Failed to save game stats. Please try again.');
+      console.error("Error ending game:", err);
+      toast.error("Failed to save game stats. Please try again.");
     } finally {
       setEndingGame(false);
     }
   };
 
-  const handleConfirmEndGame = () => {
-    setShowEndGameConfirmation(false);
-    handleEndGame();
-  };
+  /* ── DRILL results ── */
+  if (isDrill) {
+    const drillStats = game.stats || {};
+    const drillPlayerIds = game.playerIds || (game.playerId ? [game.playerId] : []);
+    const drillPlayers = drillPlayerIds.map((id) => {
+      const p = players.byId[id];
+      const s = drillStats[id] || { attempts: 0, completions: 0 };
+      return { ...p, ...s, pct: s.attempts > 0 ? Math.round((s.completions / s.attempts) * 100) : 0 };
+    }).filter((p) => p?.id);
+    const bestPlayer = drillPlayers.length ? drillPlayers.reduce((b, p) => (p.pct > b.pct ? p : b), drillPlayers[0]) : null;
 
-  const handleCancelEndGame = () => {
-    setShowEndGameConfirmation(false);
-  };
+    return (
+      <div style={{ background: "var(--ht-bg1)", minHeight: "100vh", color: "var(--ht-text)", fontFamily: "var(--ff-body)", position: "relative" }}>
+        <Confetti />
+        {/* Header */}
+        <div style={{
+          background: "linear-gradient(160deg, #0a1115, #162028)",
+          padding: "18px 20px 14px", borderBottom: "1px solid rgba(255,255,255,.06)",
+          textAlign: "center", position: "relative", zIndex: 1,
+        }}>
+          <div style={{ fontSize: "0.65rem", color: "var(--ht-muted)", letterSpacing: "0.2em", textTransform: "uppercase", marginBottom: 7 }}>
+            Drill Complete
+          </div>
+          <div style={{ fontFamily: "var(--ff-display)", fontSize: "1.1rem", color: "var(--ht-cyan)", marginBottom: 4, animation: "ht-win-reveal 0.6s ease both" }}>
+            🎯 {game.name || "Drill Session"}
+          </div>
+          <div style={{ fontSize: "0.8rem", color: "var(--ht-muted)" }}>
+            {drillPlayers.reduce((t, p) => t + p.attempts, 0)} total attempts · {drillPlayers.reduce((t, p) => t + p.completions, 0)} completions
+          </div>
+        </div>
 
-  const getGameTitle = (game) => {
-    if (game.type === 'pick-up') {
-      return `🏀 ${teamA?.name || 'Team A'} vs ${teamB?.name || 'Team B'}`;
-    }
-    if (game.type === 'drill') {
-      return `🎯 Drill – ${drillPlayer?.name || 'Player'}`;
-    }
-    return `📋 ${game.category || 'Game'}`;
-  };
+        <div style={{ padding: "16px", display: "flex", flexDirection: "column", gap: 14, overflowY: "auto" }}>
+          {/* Rings */}
+          {drillPlayers.length > 0 && (
+            <div style={{ background: "var(--ht-card)", borderRadius: "var(--ht-r)", padding: "18px", animation: "ht-slide-up 0.4s 0.1s ease both" }}>
+              <div style={{ fontSize: "0.65rem", color: "var(--ht-muted)", letterSpacing: "0.12em", fontWeight: 700, marginBottom: 16, textAlign: "center" }}>SUCCESS RATE</div>
+              <div style={{ display: "flex", justifyContent: "center", gap: 20, flexWrap: "wrap" }}>
+                {drillPlayers.map((p) => {
+                  const ringColor = p.pct >= 60 ? "var(--ht-cyan)" : p.pct >= 40 ? "var(--ht-gold)" : "#ef4444";
+                  const r = 44; const stroke = 9; const circ = 2 * Math.PI * r; const offset = circ * (1 - p.pct / 100);
+                  return (
+                    <div key={p.id} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8 }}>
+                      <div style={{ position: "relative", width: 90, height: 90 }}>
+                        <svg width={90} height={90} viewBox="0 0 90 90">
+                          <circle cx={45} cy={45} r={r} fill="none" stroke="rgba(255,255,255,.06)" strokeWidth={stroke} />
+                          <circle cx={45} cy={45} r={r} fill="none" stroke={ringColor} strokeWidth={stroke}
+                            strokeDasharray={circ} strokeDashoffset={offset} strokeLinecap="round"
+                            transform="rotate(-90 45 45)" style={{ transition: "stroke-dashoffset 1s ease" }} />
+                        </svg>
+                        <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
+                          <div style={{ fontFamily: "var(--ff-display)", fontSize: "1rem", color: "var(--ht-text)", lineHeight: 1 }}>{p.pct}%</div>
+                          <div style={{ fontSize: "0.55rem", color: "var(--ht-muted)" }}>{p.completions}/{p.attempts}</div>
+                        </div>
+                      </div>
+                      <div style={{ textAlign: "center" }}>
+                        <div style={{ fontSize: "0.8rem", fontWeight: 700, color: bestPlayer?.id === p.id ? "var(--ht-cyan)" : "var(--ht-text)" }}>
+                          {p.name} {bestPlayer?.id === p.id ? "🏅" : ""}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
 
-  const playerStats = (team) => {
-    return Object.values(team.players).map((playerId) => {
-      const player = players.byId[playerId];
-      const stats = game.stats[team.id]?.[playerId] || { ...initialStats };
-      return (
-        <tr key={player.id} className="hover:bg-gray-100 bg-gray-50 odd:bg-white even:bg-gray-50">
-          <td className="p-3 text-sm font-medium text-gray-700">{player.name}</td>
-          <td className="p-3 text-sm">{stats.freeThrows + (stats.twos * 2) + (stats.threes * 3)} pts</td>
-          <td className="p-3 text-sm">{stats.offensiveRebounds + stats.defensiveRebounds}</td>
-          <td className="p-3 text-sm">{stats.assists}</td>
-          <td className="p-3 text-sm">{stats.fouls}</td>
-        </tr>
-      );
-    });
-  };
+          {/* Table */}
+          <div style={{ background: "var(--ht-card)", borderRadius: "var(--ht-r)", overflow: "hidden", animation: "ht-slide-up 0.4s 0.3s ease both" }}>
+            <div style={{ display: "grid", gridTemplateColumns: "2fr repeat(4, 1fr)", gap: 4, padding: "8px 12px", borderBottom: "1px solid rgba(255,255,255,.04)" }}>
+              {["PLAYER", "ATT", "MADE", "%", "BEST🔥"].map((h) => (
+                <div key={h} style={{ fontSize: "0.6rem", color: "var(--ht-muted)", fontWeight: 700, letterSpacing: "0.08em", textAlign: h === "PLAYER" ? "left" : "center" }}>{h}</div>
+              ))}
+            </div>
+            {drillPlayers.map((p, i) => (
+              <div key={p.id} style={{
+                display: "grid", gridTemplateColumns: "2fr repeat(4, 1fr)", gap: 4, padding: "10px 12px",
+                borderBottom: i < drillPlayers.length - 1 ? "1px solid rgba(255,255,255,.03)" : "none",
+                background: bestPlayer?.id === p.id ? "rgba(10,166,214,.04)" : "transparent",
+              }}>
+                <div style={{ fontSize: "0.83rem", fontWeight: bestPlayer?.id === p.id ? 700 : 400, color: bestPlayer?.id === p.id ? "var(--ht-cyan)" : "var(--ht-text)" }}>
+                  {p.name}
+                </div>
+                {[p.attempts, p.completions, `${p.pct}%`, p.best || 0].map((v, j) => (
+                  <div key={j} style={{ textAlign: "center", fontFamily: "var(--ff-display)", fontSize: "0.78rem", color: j === 2 ? (p.pct >= 60 ? "var(--ht-cyan)" : p.pct >= 40 ? "var(--ht-gold)" : "var(--ht-miss)") : "var(--ht-text)" }}>
+                    {v}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
 
-  const drillPlayerStats = () => {
-    return Object.entries(drillStats).map(([id, stats]) => {
-      const player = players.byId[id];
-      return (
-        <tr key={id} className="hover:bg-gray-100 bg-gray-50 odd:bg-white even:bg-gray-50">
-          <td className="p-3 text-sm font-medium text-gray-700">{player.name}</td>
-          <td className="p-3 text-sm">Attempts: {stats.attempts}</td>
-          <td className="p-3 text-sm">Completions: {stats.completions}</td>
-          <td className="p-3 text-sm">Success Rate: {((stats.completions / (stats.attempts || 1)) * 100).toFixed(1)}%</td>
-        </tr>
-      );
-    });
+          <div style={{ display: "flex", gap: 10 }}>
+            <button onClick={onBackClick} className="ht-btn-ghost" style={{ flex: 1, padding: 13, fontSize: "0.83rem" }}>
+              ← Back
+            </button>
+            <button
+              onClick={() => setShowEndConfirm(true)}
+              disabled={endingGame}
+              style={{
+                flex: 2, padding: 13, background: "var(--ht-cyan)", border: "none", borderRadius: "var(--ht-rs)",
+                color: "#fff", fontSize: "0.88rem", fontWeight: 700, cursor: "pointer",
+                fontFamily: "var(--ff-body)", boxShadow: "0 4px 18px rgba(10,166,214,.38)",
+              }}
+            >
+              {endingGame ? "Saving..." : "Save & Exit"}
+            </button>
+          </div>
+        </div>
+
+        {showEndConfirm && (
+          <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,.7)", display: "flex", alignItems: "center", justifyContent: "center", padding: 24, zIndex: 700 }}>
+            <div style={{ background: "var(--ht-card)", borderRadius: 18, padding: "24px", width: "100%", maxWidth: 340, textAlign: "center", border: "1px solid rgba(255,255,255,.07)" }}>
+              <div style={{ fontFamily: "var(--ff-display)", fontSize: "1rem", marginBottom: 8 }}>Save drill stats?</div>
+              <div style={{ color: "var(--ht-muted)", fontSize: "0.82rem", marginBottom: 20, fontFamily: "var(--ff-body)" }}>This will save to Firebase and end the drill.</div>
+              <div style={{ display: "flex", gap: 10 }}>
+                <button onClick={() => setShowEndConfirm(false)} className="ht-btn-ghost" style={{ flex: 1, padding: "10px", fontSize: "0.85rem" }}>Cancel</button>
+                <button onClick={handleEndGame} style={{ flex: 1, padding: "10px", background: "var(--ht-cyan)", border: "none", borderRadius: 8, color: "#fff", fontSize: "0.85rem", fontWeight: 700, cursor: "pointer", fontFamily: "var(--ff-body)" }}>
+                  Save
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  /* ── PICK-UP results ── */
+  const shownTeam = statsTeam === "teamA" ? teamA : teamB;
+  const shownTeamId = statsTeam === "teamA" ? teamA?.id : teamB?.id;
+  const shownPlayers = (shownTeam?.players || []).map((id) => players.byId[id]).filter(Boolean);
+
+  const getTeamOfPlayer = (p) => {
+    if (teamA?.players?.includes(p.id)) return { team: teamA, color: "var(--ht-orange)" };
+    return { team: teamB, color: "var(--ht-cyan)" };
   };
 
   return (
-    <div className="max-w-4xl mx-auto p-6">
-      <h2 className="text-2xl sm:text-3xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-orange-500 to-cyan-500 text-center mb-6">
-        {getGameTitle(game)}
-      </h2>
+    <div style={{ background: "var(--ht-bg1)", minHeight: "100vh", color: "var(--ht-text)", fontFamily: "var(--ff-body)", position: "relative" }}>
+      <Confetti />
 
-      <div className="overflow-x-auto shadow-md rounded-lg">
-        <table className="min-w-full text-sm text-left text-gray-700">
-          <thead className="text-xs text-gray-700 uppercase bg-gray-100">
-            <tr>
-              <th scope="col" className="p-3">Player</th>
-              {isDrillMode ? (
-                <>
-                  <th scope="col" className="p-3">Attempts</th>
-                  <th scope="col" className="p-3">Completions</th>
-                  <th scope="col" className="p-3">Success Rate</th>
-                </>
-              ) : (
-                <>
-                  <th scope="col" className="p-3">Points</th>
-                  <th scope="col" className="p-3">Rebounds</th>
-                  <th scope="col" className="p-3">Assists</th>
-                  <th scope="col" className="p-3">Fouls</th>
-                </>
+      {/* Winner header */}
+      <div style={{
+        background: "linear-gradient(160deg, #0a1115 0%, #162028 100%)",
+        padding: "18px 20px 14px", borderBottom: "1px solid rgba(255,255,255,.06)",
+        position: "relative", zIndex: 1, textAlign: "center",
+      }}>
+        <div style={{ fontSize: "0.65rem", color: "var(--ht-muted)", letterSpacing: "0.2em", textTransform: "uppercase", marginBottom: 7 }}>Final Score</div>
+        {winner ? (
+          <div style={{ fontFamily: "var(--ff-display)", fontSize: "1.1rem", color: "var(--ht-gold)", marginBottom: 10, animation: "ht-win-reveal 0.6s ease both", letterSpacing: "0.06em" }}>
+            🏆 {winner.name.toUpperCase()} WIN!
+          </div>
+        ) : (
+          <div style={{ fontFamily: "var(--ff-display)", fontSize: "0.95rem", color: "var(--ht-muted)", marginBottom: 10 }}>TIE GAME</div>
+        )}
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 14 }}>
+          <div style={{ flex: 1, textAlign: "center" }}>
+            <div style={{ fontSize: "0.68rem", color: "var(--ht-orange)", letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: 4, fontWeight: 700 }}>{teamA?.name}</div>
+            <div style={{ fontFamily: "var(--ff-display)", fontSize: "3.6rem", fontWeight: 800, lineHeight: 1, color: winner?.id === teamA?.id ? "var(--ht-orange)" : "rgba(255,255,255,.45)", animation: "ht-win-reveal 0.7s 0.1s ease both" }}>
+              {game.teamAScore}
+            </div>
+          </div>
+          <div style={{ color: "var(--ht-dim)", fontFamily: "var(--ff-display)", fontSize: "1.3rem", marginTop: 20 }}>–</div>
+          <div style={{ flex: 1, textAlign: "center" }}>
+            <div style={{ fontSize: "0.68rem", color: "var(--ht-cyan)", letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: 4, fontWeight: 700 }}>{teamB?.name}</div>
+            <div style={{ fontFamily: "var(--ff-display)", fontSize: "3.6rem", fontWeight: 800, lineHeight: 1, color: winner?.id === teamB?.id ? "var(--ht-cyan)" : "rgba(255,255,255,.45)", animation: "ht-win-reveal 0.7s 0.18s ease both" }}>
+              {game.teamBScore}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ padding: "14px 16px 24px", display: "flex", flexDirection: "column", gap: 12, overflowY: "auto" }}>
+        {/* MVP */}
+        {mvp && (
+          <div style={{
+            background: "linear-gradient(135deg, var(--ht-card) 0%, rgba(251,191,36,.07) 100%)",
+            border: "1px solid rgba(251,191,36,.22)", borderRadius: "var(--ht-r)",
+            padding: "14px 16px", display: "flex", alignItems: "center", gap: 14,
+            animation: "ht-slide-up 0.5s 0.25s ease both", position: "relative", overflow: "hidden",
+          }}>
+            <div style={{
+              position: "absolute", top: 0, left: 0, width: "40%", height: "100%",
+              background: "linear-gradient(90deg, transparent, rgba(251,191,36,.05), transparent)",
+              animation: "ht-shimmer 3s ease-in-out infinite",
+            }} />
+            <div style={{
+              width: 50, height: 50, borderRadius: "50%", background: "rgba(251,191,36,.12)",
+              border: "2px solid rgba(251,191,36,.4)", display: "flex", alignItems: "center", justifyContent: "center",
+              fontFamily: "var(--ff-display)", fontSize: "0.85rem", color: "var(--ht-gold)", flexShrink: 0,
+            }}>
+              #{mvp.player.number}
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: "0.62rem", color: "var(--ht-gold)", letterSpacing: "0.15em", textTransform: "uppercase", marginBottom: 2 }}>🏅 MVP</div>
+              <div style={{ fontSize: "1.05rem", fontWeight: 800, marginBottom: 5 }}>{mvp.player.name}</div>
+              <div style={{ display: "flex", gap: 14 }}>
+                {[{ l: "PTS", v: getPts(mvp.stats) }, { l: "REB", v: getReb(mvp.stats) }, { l: "AST", v: getAst(mvp.stats) }].map(({ l, v }) => (
+                  <div key={l} style={{ textAlign: "center" }}>
+                    <div style={{ fontFamily: "var(--ff-display)", fontSize: "1.15rem", color: "var(--ht-gold)", lineHeight: 1 }}>{v}</div>
+                    <div style={{ fontSize: "0.6rem", color: "var(--ht-muted)", letterSpacing: "0.08em", marginTop: 2 }}>{l}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Stats table */}
+        <div style={{ background: "var(--ht-card)", borderRadius: "var(--ht-r)", overflow: "hidden", animation: "ht-slide-up 0.5s 0.35s ease both" }}>
+          <div style={{ display: "flex", borderBottom: "1px solid rgba(255,255,255,.05)" }}>
+            {["teamA", "teamB"].map((tk) => {
+              const t = tk === "teamA" ? teamA : teamB;
+              const on = statsTeam === tk;
+              const c = tk === "teamA" ? "var(--ht-orange)" : "var(--ht-cyan)";
+              return (
+                <button key={tk} onClick={() => setStatsTeam(tk)} style={{
+                  flex: 1, padding: "10px", border: "none",
+                  background: on ? c + "14" : "transparent",
+                  color: on ? c : "var(--ht-muted)",
+                  fontSize: "0.83rem", fontWeight: 700, cursor: "pointer",
+                  borderBottom: `2px solid ${on ? c : "transparent"}`,
+                  transition: "all 0.15s", letterSpacing: "0.06em", fontFamily: "var(--ff-body)",
+                }}>
+                  {t?.name}
+                </button>
+              );
+            })}
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "2fr repeat(4, 1fr)", gap: 4, padding: "8px 12px", borderBottom: "1px solid rgba(255,255,255,.04)" }}>
+            {["PLAYER", "PTS", "REB", "AST", "PF"].map((h) => (
+              <div key={h} style={{ fontSize: "0.6rem", color: "var(--ht-muted)", fontWeight: 700, letterSpacing: "0.1em", textAlign: h === "PLAYER" ? "left" : "center" }}>{h}</div>
+            ))}
+          </div>
+          {shownPlayers.map((p, i) => {
+            const s = game.stats?.[shownTeamId]?.[p.id] || { ...initialStats };
+            const isMvp = mvp?.player?.id === p.id;
+            return (
+              <div
+                key={p.id}
+                onClick={() => setProfilePlayer(p)}
+                style={{
+                  display: "grid", gridTemplateColumns: "2fr repeat(4, 1fr)", gap: 4, padding: "10px 12px",
+                  borderBottom: i < shownPlayers.length - 1 ? "1px solid rgba(255,255,255,.03)" : "none",
+                  background: isMvp ? "rgba(251,191,36,.035)" : "transparent",
+                  cursor: "pointer", transition: "background 0.15s",
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.background = isMvp ? "rgba(251,191,36,.07)" : "rgba(255,255,255,.03)"}
+                onMouseLeave={(e) => e.currentTarget.style.background = isMvp ? "rgba(251,191,36,.035)" : "transparent"}
+              >
+                <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+                  <span style={{ fontSize: "0.7rem", color: "var(--ht-muted)", fontFamily: "var(--ff-display)", minWidth: 22 }}>#{p.number}</span>
+                  <span style={{ fontSize: "0.83rem", fontWeight: isMvp ? 700 : 400, color: isMvp ? "var(--ht-gold)" : "var(--ht-text)" }}>
+                    {p.name}{isMvp ? " 👑" : ""}
+                  </span>
+                  <span style={{ fontSize: "0.55rem", color: "var(--ht-dim)", marginLeft: "auto" }}>›</span>
+                </div>
+                {[getPts(s), getReb(s), getAst(s), getFouls(s)].map((v, j) => (
+                  <div key={j} style={{ textAlign: "center", fontFamily: "var(--ff-display)", fontSize: "0.82rem", color: v > 0 ? "var(--ht-text)" : "var(--ht-dim)" }}>{v}</div>
+                ))}
+              </div>
+            );
+          })}
+          <div style={{ padding: "6px 12px", borderTop: "1px solid rgba(255,255,255,.04)" }}>
+            <div style={{ fontSize: "0.58rem", color: "var(--ht-dim)", letterSpacing: "0.06em" }}>Tap a player to see full stats →</div>
+          </div>
+        </div>
+
+        {/* Social share */}
+        <div style={{ background: "var(--ht-card)", borderRadius: "var(--ht-r)", padding: "16px", animation: "ht-slide-up 0.5s 0.45s ease both" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}>
+            <div style={{ flex: 1, height: 1, background: "rgba(255,255,255,.06)" }} />
+            <div style={{ fontSize: "0.68rem", color: "var(--ht-muted)", letterSpacing: "0.14em", fontWeight: 700, whiteSpace: "nowrap" }}>Share the W</div>
+            <div style={{ flex: 1, height: 1, background: "rgba(255,255,255,.06)" }} />
+          </div>
+
+          {/* Share card preview */}
+          <div
+            ref={shareCardRef}
+            style={{
+              background: "#0e191d", borderRadius: 12, overflow: "hidden",
+              fontFamily: "Audiowide, sans-serif", border: "1px solid rgba(255,255,255,.06)",
+            }}
+          >
+            <div style={{ height: 4, background: "linear-gradient(90deg, var(--ht-orange), var(--ht-cyan))" }} />
+            <div style={{ padding: "14px 16px 0" }}>
+              <div style={{ fontSize: "0.5rem", color: "#6b8899", letterSpacing: "0.14em", textAlign: "center", marginBottom: 10, fontFamily: "Barlow Condensed, sans-serif", fontWeight: 700 }}>
+                GAME RECAP · HOOPTRACKR
+              </div>
+              {winner && (
+                <div style={{ textAlign: "center", color: "#fbbf24", fontSize: "0.78rem", marginBottom: 10, letterSpacing: "0.06em" }}>
+                  🏆 {winner.name.toUpperCase()} WIN!
+                </div>
               )}
-            </tr>
-          </thead>
-          <tbody>
-            {isDrillMode ? drillPlayerStats() : (
-              <>
-                {teamA && playerStats(teamA)}
-                {teamB && playerStats(teamB)}
-              </>
-            )}
-          </tbody>
-        </table>
-      </div>
+              <div style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 10, marginBottom: 10 }}>
+                <div style={{ flex: 1, textAlign: "center" }}>
+                  <div style={{ fontSize: "0.55rem", color: "#f64e07", letterSpacing: "0.08em", marginBottom: 3, textTransform: "uppercase", fontFamily: "Barlow Condensed, sans-serif", fontWeight: 700 }}>{teamA?.name}</div>
+                  <div style={{ fontSize: "2.6rem", color: winner?.id === teamA?.id ? "#f64e07" : "rgba(255,255,255,.45)", lineHeight: 1 }}>{game.teamAScore}</div>
+                </div>
+                <div style={{ color: "#2e4a57", fontSize: "1.4rem" }}>–</div>
+                <div style={{ flex: 1, textAlign: "center" }}>
+                  <div style={{ fontSize: "0.55rem", color: "#0aa6d6", letterSpacing: "0.08em", marginBottom: 3, textTransform: "uppercase", fontFamily: "Barlow Condensed, sans-serif", fontWeight: 700 }}>{teamB?.name}</div>
+                  <div style={{ fontSize: "2.6rem", color: winner?.id === teamB?.id ? "#0aa6d6" : "rgba(255,255,255,.45)", lineHeight: 1 }}>{game.teamBScore}</div>
+                </div>
+              </div>
+              {mvp && (
+                <div style={{ background: "rgba(251,191,36,.1)", border: "1px solid rgba(251,191,36,.22)", borderRadius: 8, padding: "8px 10px", marginBottom: 10 }}>
+                  <div style={{ fontSize: "0.48rem", color: "#fbbf24", letterSpacing: "0.14em", marginBottom: 3, fontFamily: "Barlow Condensed, sans-serif", fontWeight: 700 }}>🏅 MVP</div>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                    <div style={{ fontSize: "0.82rem", fontWeight: 700, fontFamily: "Barlow Condensed, sans-serif", color: "#fff" }}>{mvp.player.name}</div>
+                    <div style={{ display: "flex", gap: 10 }}>
+                      {[{ l: "PTS", v: getPts(mvp.stats) }, { l: "REB", v: getReb(mvp.stats) }, { l: "AST", v: getAst(mvp.stats) }].map(({ l, v }) => (
+                        <div key={l} style={{ textAlign: "center" }}>
+                          <div style={{ fontSize: "0.82rem", color: "#fbbf24" }}>{v}</div>
+                          <div style={{ fontSize: "0.44rem", color: "#6b8899", letterSpacing: "0.06em", fontFamily: "Barlow Condensed, sans-serif" }}>{l}</div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+            <div style={{ background: "rgba(246,78,7,.08)", padding: "7px 16px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <span style={{ fontSize: "0.5rem", color: "#f64e07", letterSpacing: "0.1em", fontFamily: "Barlow Condensed, sans-serif", fontWeight: 700 }}>HOOPTRACKR.APP</span>
+              <span style={{ fontSize: "0.5rem", color: "#6b8899", fontFamily: "Barlow Condensed, sans-serif" }}>Track your game 🏀</span>
+            </div>
+          </div>
 
-      <div className="mt-6 text-center space-x-4">
-        <button
-          onClick={onBackClick}
-          className="inline-flex items-center px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm font-medium rounded-md"
-        >
-          ← Back to Game
-        </button>
-        <button
-          onClick={() => setShowEndGameConfirmation(true)}
-          disabled={endingGame}
-          className="inline-flex items-center px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-md disabled:opacity-60 disabled:cursor-not-allowed"
-        >
-          {endingGame ? 'Saving...' : `End ${isDrillMode ? 'Drill' : 'Game'}`}
-        </button>
-      </div>
-
-      {/* End Game Confirmation Modal */}
-      {showEndGameConfirmation && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
-            <h2 className="text-2xl font-bold mb-4 text-center">
-              End {isDrillMode ? "Drill" : "Game"}?
-            </h2>
-            <p className="text-gray-600 mb-6 text-center">
-              Are you sure you want to end this {isDrillMode ? "drill" : "game"}? 
-              This action cannot be undone.
-            </p>
-            <div className="flex justify-center space-x-4">
+          {/* Share buttons */}
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 8, margin: "12px 0 10px" }}>
+            {[
+              { icon: "𝕏", label: "Twitter", color: "#1DA1F2", p: "twitter" },
+              { icon: "💬", label: "WhatsApp", color: "#25D366", p: "whatsapp" },
+              { icon: copied ? "✅" : "🔗", label: copied ? "Copied!" : "Copy", color: "var(--ht-cyan)", p: "copy" },
+            ].map(({ icon, label, color, p }) => (
               <button
-                onClick={handleCancelEndGame}
-                className="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-800 rounded-md"
+                key={label}
+                onClick={() => handleShare(p)}
+                style={{
+                  padding: "10px 4px", background: "var(--ht-card2)", border: "1px solid rgba(255,255,255,.06)",
+                  borderRadius: 10, cursor: "pointer", display: "flex", flexDirection: "column", alignItems: "center", gap: 5,
+                  transition: "transform 0.1s",
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.transform = "scale(1.05)"}
+                onMouseLeave={(e) => e.currentTarget.style.transform = "scale(1)"}
+                onMouseDown={(e) => e.currentTarget.style.transform = "scale(.95)"}
+                onMouseUp={(e) => e.currentTarget.style.transform = "scale(1)"}
               >
-                Cancel
+                <div style={{ fontSize: "1.3rem" }}>{icon}</div>
+                <div style={{ fontSize: "0.62rem", color, fontWeight: 700, letterSpacing: "0.04em", fontFamily: "var(--ff-body)" }}>{label}</div>
               </button>
-              <button
-                onClick={handleConfirmEndGame}
-                className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md"
-              >
-                End {isDrillMode ? "Drill" : "Game"}
+            ))}
+          </div>
+        </div>
+
+        {/* Bottom actions */}
+        <div style={{ display: "flex", gap: 10 }}>
+          <button onClick={onBackClick} className="ht-btn-ghost" style={{ flex: 1, padding: 13, fontSize: "0.83rem" }}>
+            ← Back
+          </button>
+          <button
+            onClick={() => setShowEndConfirm(true)}
+            disabled={endingGame}
+            style={{
+              flex: 2, padding: 13, background: "var(--ht-orange)", border: "none", borderRadius: "var(--ht-rs)",
+              color: "#fff", fontSize: "0.88rem", fontWeight: 700, cursor: "pointer",
+              fontFamily: "var(--ff-body)", letterSpacing: "0.07em", boxShadow: "0 4px 18px rgba(246,78,7,.38)",
+              opacity: endingGame ? 0.6 : 1,
+            }}
+          >
+            {endingGame ? "Saving..." : "🏀 Save & Exit"}
+          </button>
+        </div>
+      </div>
+
+      {/* Player profile modal */}
+      {profilePlayer && (() => {
+        const { team: t, color: c } = getTeamOfPlayer(profilePlayer);
+        const pid = profilePlayer.id;
+        const tid = t?.id;
+        return (
+          <PlayerProfileModal
+            player={profilePlayer}
+            stats={game.stats?.[tid]?.[pid]}
+            teamColor={c}
+            teamName={t?.name}
+            onClose={() => setProfilePlayer(null)}
+          />
+        );
+      })()}
+
+      {/* Share toast */}
+      {shareToast && (
+        <div style={{
+          position: "fixed", bottom: 90, left: "50%", transform: "translateX(-50%)",
+          background: "rgba(255,255,255,.12)", backdropFilter: "blur(12px)",
+          padding: "8px 18px", borderRadius: 50, fontSize: "0.8rem", fontWeight: 700,
+          color: "#fff", whiteSpace: "nowrap", animation: "ht-slide-up 0.2s ease",
+          border: "1px solid rgba(255,255,255,.1)", zIndex: 700, fontFamily: "var(--ff-body)",
+        }}>
+          {shareToast}
+        </div>
+      )}
+
+      {/* End game confirmation */}
+      {showEndConfirm && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,.7)", display: "flex", alignItems: "center", justifyContent: "center", padding: 24, zIndex: 700 }}>
+          <div style={{ background: "var(--ht-card)", borderRadius: 18, padding: "24px", width: "100%", maxWidth: 340, textAlign: "center", border: "1px solid rgba(255,255,255,.07)" }}>
+            <div style={{ fontFamily: "var(--ff-display)", fontSize: "1rem", marginBottom: 8 }}>Save game stats?</div>
+            <div style={{ color: "var(--ht-muted)", fontSize: "0.82rem", marginBottom: 20, fontFamily: "var(--ff-body)" }}>This will save to Firebase and end the game.</div>
+            <div style={{ display: "flex", gap: 10 }}>
+              <button onClick={() => setShowEndConfirm(false)} className="ht-btn-ghost" style={{ flex: 1, padding: "10px", fontSize: "0.85rem" }}>Cancel</button>
+              <button onClick={handleEndGame} style={{ flex: 1, padding: "10px", background: "var(--ht-orange)", border: "none", borderRadius: 8, color: "#fff", fontSize: "0.85rem", fontWeight: 700, cursor: "pointer", fontFamily: "var(--ff-body)" }}>
+                Save
               </button>
             </div>
           </div>

--- a/src/components/Scoreboard.js
+++ b/src/components/Scoreboard.js
@@ -1,40 +1,182 @@
-import React from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useSelector } from "react-redux";
 
 const Scoreboard = ({ currentGameId }) => {
   const currentGame = useSelector((state) => state.games.byId[currentGameId]);
+  const teams = useSelector((state) => state.teams);
+  const teamA = teams.byId[currentGame.teamAId];
+  const teamB = teams.byId[currentGame.teamBId];
   const teamAScore = currentGame.teamAScore;
   const teamBScore = currentGame.teamBScore;
 
-  return (
-    <div className="Scoreboard flex flex-col items-center w-4/5 justify-center space-y-6 p-6 bg-black bg-opacity-50 rounded-lg shadow-xl text-white">
-      {/* Scoreboard Title */}
-      <h2 className="text-3xl md:text-4xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-[#f64e07] to-[#0aa6d6] tracking-wider relative">
-        Scoreboard
-        <span className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-[#f64e07] via-transparent to-[#0aa6d6]"></span>
-      </h2>
+  const [flashTeam, setFlashTeam] = useState(null);
+  const prevScores = useRef({ a: teamAScore, b: teamBScore });
 
-      {/* Team Scores */}
-      <div className="flex flex-row justify-around w-full max-w-lg items-center">
-        {/* Home Team Score */}
-        <div className="flex flex-col items-center space-y-2 bg-gray-800 bg-opacity-90 py-4 px-6 sm:px-8 md:px-10 lg:px-12 rounded-lg shadow-md w-full sm:w-3/4 lg:w-1/2">
-          <h3 className="text-lg sm:text-xl font-semibold tracking-widest text-center">
-            Home
-          </h3>
-          <div className="points text-4xl sm:text-5xl md:text-6xl font-extrabold text-white">
+  useEffect(() => {
+    if (teamAScore > prevScores.current.a) {
+      setFlashTeam("teamA");
+      setTimeout(() => setFlashTeam(null), 450);
+    } else if (teamBScore > prevScores.current.b) {
+      setFlashTeam("teamB");
+      setTimeout(() => setFlashTeam(null), 450);
+    }
+    prevScores.current = { a: teamAScore, b: teamBScore };
+  }, [teamAScore, teamBScore]);
+
+  return (
+    <div
+      style={{
+        background: "linear-gradient(to bottom, #0a1115, var(--ht-bg1))",
+        padding: "14px 18px 12px",
+        borderBottom: "1px solid rgba(255,255,255,0.055)",
+        flexShrink: 0,
+      }}
+    >
+      {/* Top bar: live pill + logo + end button placeholder */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 12,
+        }}
+      >
+        <div
+          style={{
+            fontSize: "0.72rem",
+            color: "var(--ht-muted)",
+            letterSpacing: "0.08em",
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+          }}
+        >
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: "#4ade80",
+              display: "inline-block",
+              animation: "ht-pulse-dot 1.5s infinite",
+            }}
+          />
+          LIVE
+        </div>
+        <div
+          style={{
+            fontFamily: "var(--ff-display)",
+            fontSize: "0.75rem",
+            color: "var(--ht-orange)",
+            letterSpacing: "0.08em",
+          }}
+        >
+          HOOPTRACKR
+        </div>
+        {/* spacer to match width */}
+        <div style={{ width: 60 }} />
+      </div>
+
+      {/* Scores */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 16,
+        }}
+      >
+        {/* Team A */}
+        <div style={{ flex: 1, textAlign: "center" }}>
+          <div
+            style={{
+              fontSize: "0.7rem",
+              color: "var(--ht-orange)",
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              marginBottom: 4,
+              fontWeight: 700,
+              fontFamily: "var(--ff-body)",
+            }}
+          >
+            {teamA?.name || "Home"}
+          </div>
+          <div
+            className={flashTeam === "teamA" ? "ht-score-pop" : ""}
+            style={{
+              fontFamily: "var(--ff-display)",
+              fontSize: "3.4rem",
+              fontWeight: 800,
+              color: "var(--ht-orange)",
+              lineHeight: 1,
+              transition: "color 0.3s",
+            }}
+          >
             {teamAScore}
           </div>
         </div>
 
-        {/* Glowing Divider */}
-        <div className="w-px h-16 mx-4 sm:mx-6 bg-gradient-to-b from-[#f64e07] to-[#0aa6d6] opacity-80"></div>
+        {/* Divider */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 3,
+          }}
+        >
+          <div
+            style={{
+              width: 1,
+              height: 18,
+              background: "linear-gradient(to bottom, var(--ht-orange), var(--ht-cyan))",
+            }}
+          />
+          <div
+            style={{
+              fontSize: "0.65rem",
+              color: "var(--ht-dim)",
+              letterSpacing: "0.08em",
+              fontFamily: "var(--ff-body)",
+            }}
+          >
+            VS
+          </div>
+          <div
+            style={{
+              width: 1,
+              height: 18,
+              background: "linear-gradient(to bottom, var(--ht-cyan), transparent)",
+            }}
+          />
+        </div>
 
-        {/* Away Team Score */}
-        <div className="flex flex-col items-center space-y-2 bg-gray-800 bg-opacity-90 py-4 px-6 sm:px-8 md:px-10 lg:px-12 rounded-lg shadow-md w-full sm:w-3/4 lg:w-1/2">
-          <h3 className="text-lg sm:text-xl font-semibold tracking-widest text-center">
-            Away
-          </h3>
-          <div className="points text-4xl sm:text-5xl md:text-6xl font-extrabold text-white">
+        {/* Team B */}
+        <div style={{ flex: 1, textAlign: "center" }}>
+          <div
+            style={{
+              fontSize: "0.7rem",
+              color: "var(--ht-cyan)",
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              marginBottom: 4,
+              fontWeight: 700,
+              fontFamily: "var(--ff-body)",
+            }}
+          >
+            {teamB?.name || "Away"}
+          </div>
+          <div
+            className={flashTeam === "teamB" ? "ht-score-pop" : ""}
+            style={{
+              fontFamily: "var(--ff-display)",
+              fontSize: "3.4rem",
+              fontWeight: 800,
+              color: "var(--ht-cyan)",
+              lineHeight: 1,
+              transition: "color 0.3s",
+            }}
+          >
             {teamBScore}
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,215 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ── HoopTrackr v2 Design System ── */
+:root {
+  --ht-bg: #080f12;
+  --ht-bg1: #0e191d;
+  --ht-card: #14232a;
+  --ht-card2: #1c2f38;
+  --ht-card3: #243545;
+  --ht-orange: #f64e07;
+  --ht-orange-dim: rgba(246, 78, 7, 0.14);
+  --ht-orange-glow: rgba(246, 78, 7, 0.4);
+  --ht-cyan: #0aa6d6;
+  --ht-cyan-dim: rgba(10, 166, 214, 0.14);
+  --ht-miss: #ef4444;
+  --ht-miss-dim: rgba(239, 68, 68, 0.12);
+  --ht-gold: #fbbf24;
+  --ht-green: #4ade80;
+  --ht-text: #fff;
+  --ht-muted: #6b8899;
+  --ht-dim: #2e4a57;
+  --ht-r: 14px;
+  --ht-rs: 9px;
+  --ff-display: 'Audiowide', sans-serif;
+  --ff-body: 'Barlow Condensed', sans-serif;
+}
+
+/* ── Game screen full-page wrapper ── */
+.ht-game-screen {
+  min-height: 100vh;
+  background: var(--ht-bg);
+  display: flex;
+  flex-direction: column;
+  font-family: var(--ff-body);
+  color: var(--ht-text);
+  overflow: hidden;
+}
+
+/* ── Keyframes ── */
+@keyframes ht-confetti-fall {
+  0%   { transform: translateY(-30px) rotate(0deg); opacity: 1; }
+  85%  { opacity: 0.8; }
+  100% { transform: translateY(110vh) rotate(800deg); opacity: 0; }
+}
+@keyframes ht-score-float {
+  0%   { transform: translateY(0) scale(1.1); opacity: 1; }
+  100% { transform: translateY(-90px) scale(0.7); opacity: 0; }
+}
+@keyframes ht-score-pop {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.4); }
+  70%  { transform: scale(0.95); }
+  100% { transform: scale(1); }
+}
+@keyframes ht-made-flash {
+  0%   { box-shadow: 0 6px 28px rgba(246,78,7,.45); }
+  40%  { box-shadow: 0 0 60px rgba(246,78,7,.9), 0 0 120px rgba(246,78,7,.4); }
+  100% { box-shadow: 0 6px 28px rgba(246,78,7,.45); }
+}
+@keyframes ht-drill-flash {
+  0%   { box-shadow: 0 6px 28px rgba(34,197,94,.4); }
+  40%  { box-shadow: 0 0 60px rgba(34,197,94,.9); }
+  100% { box-shadow: 0 6px 28px rgba(34,197,94,.4); }
+}
+@keyframes ht-slide-up {
+  from { transform: translateY(24px); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+@keyframes ht-slide-in {
+  from { transform: translateY(100%); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+@keyframes ht-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes ht-win-reveal {
+  0%   { transform: scale(0.6) translateY(16px); opacity: 0; }
+  65%  { transform: scale(1.06) translateY(-3px); }
+  100% { transform: scale(1) translateY(0); opacity: 1; }
+}
+@keyframes ht-shimmer {
+  0%   { transform: translateX(-200%); }
+  100% { transform: translateX(400%); }
+}
+@keyframes ht-fire-glow {
+  0%, 100% { text-shadow: 0 0 8px rgba(251,191,36,.8); }
+  50%       { text-shadow: 0 0 20px rgba(251,191,36,1), 0 0 40px rgba(246,78,7,.5); }
+}
+@keyframes ht-pulse-ring {
+  0%   { box-shadow: 0 0 0 0 rgba(246,78,7,.5); }
+  100% { box-shadow: 0 0 0 10px rgba(246,78,7,0); }
+}
+@keyframes ht-pulse-dot {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+
+/* ── Reusable animation classes ── */
+.ht-score-pop  { animation: ht-score-pop  0.4s cubic-bezier(.36,.07,.19,.97); }
+.ht-slide-up   { animation: ht-slide-up   0.35s ease both; }
+.ht-fade-in    { animation: ht-fade-in    0.15s ease; }
+.ht-win-reveal { animation: ht-win-reveal 0.6s ease both; }
+
+/* ── MADE button ── */
+.ht-btn-made {
+  width: 100%;
+  border: none;
+  border-radius: var(--ht-r);
+  color: #fff;
+  cursor: pointer;
+  font-family: var(--ff-display);
+  letter-spacing: 0.08em;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  background: linear-gradient(145deg, #ff6b2a, var(--ht-orange), #cc3d00);
+  box-shadow: 0 6px 28px rgba(246,78,7,.45), inset 0 1px 0 rgba(255,255,255,.18);
+  transition: transform 0.1s, box-shadow 0.1s;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+}
+.ht-btn-made:active { transform: scale(0.96); box-shadow: 0 2px 12px rgba(246,78,7,.6); }
+.ht-btn-made::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(255,255,255,.14) 0%, transparent 50%);
+  pointer-events: none;
+}
+.ht-btn-made.flash { animation: ht-made-flash 0.35s ease; }
+
+/* ── MADE (drill) button ── */
+.ht-btn-made-drill {
+  width: 100%;
+  border: none;
+  border-radius: var(--ht-r);
+  color: #fff;
+  cursor: pointer;
+  font-family: var(--ff-display);
+  letter-spacing: 0.08em;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  background: linear-gradient(145deg, #22c55e, #16a34a, #15803d);
+  box-shadow: 0 6px 28px rgba(34,197,94,.4), inset 0 1px 0 rgba(255,255,255,.18);
+  transition: transform 0.1s;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+}
+.ht-btn-made-drill:active { transform: scale(0.96); }
+.ht-btn-made-drill::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(255,255,255,.14) 0%, transparent 50%);
+  pointer-events: none;
+}
+.ht-btn-made-drill.flash { animation: ht-drill-flash 0.35s ease; }
+
+/* ── MISS button ── */
+.ht-btn-miss {
+  width: 100%;
+  border-radius: var(--ht-r);
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  background: var(--ht-miss-dim);
+  border: 1.5px solid rgba(239,68,68,.28);
+  color: #f87171;
+  font-family: var(--ff-body);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  transition: transform 0.1s, background 0.1s;
+}
+.ht-btn-miss:active { transform: scale(0.96); background: rgba(239,68,68,.22); }
+
+/* ── Ghost button ── */
+.ht-btn-ghost {
+  background: var(--ht-card);
+  border: 1px solid rgba(255,255,255,.07);
+  border-radius: var(--ht-rs);
+  color: var(--ht-muted);
+  font-family: var(--ff-body);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.ht-btn-ghost:active { background: var(--ht-card2); }
+
+/* ── Stat buttons ── */
+.ht-btn-stat {
+  flex: 1;
+  border-radius: var(--ht-rs);
+  border: 1.5px solid rgba(255,255,255,.07);
+  background: var(--ht-card2);
+  color: var(--ht-text);
+  font-family: var(--ff-body);
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.1s, background 0.15s;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+.ht-btn-stat:active { transform: scale(0.94); background: var(--ht-card3); }

--- a/src/pages/DrillTracking/index.js
+++ b/src/pages/DrillTracking/index.js
@@ -1,102 +1,562 @@
-import React, { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
-import { Navigate, useParams } from 'react-router-dom'
-import GameControls from '../../components/GameControls';
-import BgImg from '../../components/BackgroundImage';
+import React, { useState, useEffect, useMemo, useCallback } from "react";
+import { v4 as uuid } from "uuid";
+import { Navigate, useParams, useNavigate } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
+import {
+  addDrillAttempt,
+  addDrillCompletion,
+  updateLastActions,
+  undoLastAction,
+  endGame,
+} from "../../redux/games-reducer";
+import GameResult from "../../components/GameResults";
 
+/* ── Progress ring (SVG) ── */
+function ProgressRing({ pct = 0, size = 148, stroke = 13, color = "var(--ht-cyan)", label = "", sublabel = "" }) {
+  const [anim, setAnim] = useState(0);
+  useEffect(() => {
+    const t = setTimeout(() => setAnim(pct), 60);
+    return () => clearTimeout(t);
+  }, [pct]);
+  const r = (size - stroke) / 2;
+  const circ = 2 * Math.PI * r;
+  const offset = circ * (1 - anim / 100);
+  return (
+    <div style={{ position: "relative", width: size, height: size }}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="rgba(255,255,255,.06)" strokeWidth={stroke} />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke={color}
+          strokeWidth={stroke}
+          strokeDasharray={circ}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${size / 2} ${size / 2})`}
+          style={{
+            transition: "stroke-dashoffset 1s cubic-bezier(.4,0,.2,1)",
+            filter: `drop-shadow(0 0 6px ${color === "var(--ht-cyan)" ? "#0aa6d6" : "#ef4444"}80)`,
+          }}
+        />
+      </svg>
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 1,
+        }}
+      >
+        <div style={{ fontFamily: "var(--ff-display)", fontSize: size * 0.18, color: "var(--ht-text)", lineHeight: 1 }}>
+          {pct}%
+        </div>
+        {label && (
+          <div style={{ fontSize: size * 0.1, color: "var(--ht-muted)", fontWeight: 700, letterSpacing: "0.06em", fontFamily: "var(--ff-body)" }}>
+            {label}
+          </div>
+        )}
+        {sublabel && (
+          <div style={{ fontSize: size * 0.085, color: "var(--ht-dim)", fontFamily: "var(--ff-body)" }}>
+            {sublabel}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Mini ring ── */
+function MiniRing({ pct = 0, size = 56, name, pts }) {
+  const [anim, setAnim] = useState(0);
+  useEffect(() => {
+    const t = setTimeout(() => setAnim(pct), 80);
+    return () => clearTimeout(t);
+  }, [pct]);
+  const stroke = 5;
+  const r = (size - stroke) / 2;
+  const circ = 2 * Math.PI * r;
+  const offset = circ * (1 - anim / 100);
+  const color = pct >= 60 ? "var(--ht-cyan)" : "#ef4444";
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
+      <div style={{ position: "relative", width: size, height: size }}>
+        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="rgba(255,255,255,.06)" strokeWidth={stroke} />
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={r}
+            fill="none"
+            stroke={color}
+            strokeWidth={stroke}
+            strokeDasharray={circ}
+            strokeDashoffset={offset}
+            strokeLinecap="round"
+            transform={`rotate(-90 ${size / 2} ${size / 2})`}
+            style={{ transition: "stroke-dashoffset 0.8s ease" }}
+          />
+        </svg>
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontFamily: "var(--ff-display)",
+            fontSize: size * 0.2,
+            color: "var(--ht-text)",
+          }}
+        >
+          {pct}%
+        </div>
+      </div>
+      <div style={{ fontSize: "0.65rem", color: "var(--ht-text)", fontWeight: 700, textAlign: "center", fontFamily: "var(--ff-body)" }}>
+        {name}
+      </div>
+      <div style={{ fontSize: "0.55rem", color: "var(--ht-muted)", fontFamily: "var(--ff-body)" }}>{pts}</div>
+    </div>
+  );
+}
+
+/* ── Float particles ── */
+function FloatParticles({ items }) {
+  return (
+    <div style={{ position: "fixed", inset: 0, pointerEvents: "none", overflow: "hidden", zIndex: 9999 }}>
+      {items.map((p) => (
+        <div
+          key={p.id}
+          style={{
+            position: "absolute",
+            left: `${p.x}%`,
+            top: `${p.y}%`,
+            fontFamily: "var(--ff-display)",
+            fontWeight: 800,
+            fontSize: "1.9rem",
+            color: p.made ? "var(--ht-green)" : "#f87171",
+            textShadow: p.made ? "0 0 16px rgba(74,222,128,.7)" : "0 0 12px rgba(239,68,68,.7)",
+            animation: "ht-score-float 0.95s ease-out forwards",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {p.made ? "✓" : "✕"}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ── Player bottom sheet ── */
+function PlayerSheet({ players, selected, onSelect, onClose }) {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.8)",
+        backdropFilter: "blur(10px)",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "flex-end",
+        zIndex: 200,
+        animation: "ht-fade-in 0.15s ease",
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: "var(--ht-card)",
+          borderRadius: "20px 20px 0 0",
+          padding: "20px 20px 32px",
+          animation: "ht-slide-in 0.22s ease",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 18 }}>
+          <div style={{ fontFamily: "var(--ff-display)", fontSize: "0.9rem", color: "var(--ht-cyan)", letterSpacing: "0.08em" }}>
+            SELECT PLAYER
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              width: 30, height: 30, borderRadius: "50%", background: "rgba(255,255,255,.08)",
+              border: "none", color: "var(--ht-muted)", cursor: "pointer", fontSize: "1rem",
+              display: "flex", alignItems: "center", justifyContent: "center",
+            }}
+          >×</button>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 10 }}>
+          {players.map((p) => {
+            const on = selected?.id === p.id;
+            return (
+              <button
+                key={p.id}
+                onClick={() => onSelect(p)}
+                style={{
+                  padding: "14px 8px",
+                  background: on ? "rgba(10,166,214,.25)" : "var(--ht-card2)",
+                  border: `2px solid ${on ? "var(--ht-cyan)" : "rgba(255,255,255,.06)"}`,
+                  borderRadius: 12, cursor: "pointer",
+                  display: "flex", flexDirection: "column", alignItems: "center", gap: 5,
+                  transition: "all 0.1s",
+                  boxShadow: on ? "0 0 14px rgba(10,166,214,.35)" : "none",
+                }}
+              >
+                <div style={{ fontFamily: "var(--ff-display)", fontSize: "1.25rem", color: on ? "var(--ht-cyan)" : "var(--ht-text)" }}>
+                  #{p.number}
+                </div>
+                <div style={{ fontSize: "0.75rem", color: on ? "var(--ht-text)" : "var(--ht-muted)", fontWeight: 700, textAlign: "center", fontFamily: "var(--ff-body)" }}>
+                  {p.name}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── End modal ── */
+function EndModal({ onConfirm, onCancel }) {
+  return (
+    <div
+      style={{
+        position: "fixed", inset: 0, background: "rgba(0,0,0,0.82)", backdropFilter: "blur(10px)",
+        display: "flex", alignItems: "center", justifyContent: "center", padding: 24, zIndex: 300,
+      }}
+    >
+      <div style={{
+        background: "var(--ht-card)", borderRadius: 18, padding: "28px 24px", width: "100%", maxWidth: 360,
+        textAlign: "center", animation: "ht-slide-up 0.2s ease", border: "1px solid rgba(255,255,255,.07)",
+      }}>
+        <div style={{ fontSize: "2.2rem", marginBottom: 12 }}>🏁</div>
+        <div style={{ fontFamily: "var(--ff-display)", fontSize: "1.1rem", marginBottom: 8, color: "var(--ht-text)" }}>
+          End Drill?
+        </div>
+        <div style={{ color: "var(--ht-muted)", fontSize: "0.84rem", marginBottom: 24, lineHeight: 1.6, fontFamily: "var(--ff-body)" }}>
+          Results and success rates will be shown.
+        </div>
+        <div style={{ display: "flex", gap: 10 }}>
+          <button onClick={onCancel} className="ht-btn-ghost" style={{ flex: 1, padding: "12px", fontSize: "0.88rem" }}>
+            Keep Going
+          </button>
+          <button
+            onClick={onConfirm}
+            style={{
+              flex: 1, padding: "12px", background: "var(--ht-cyan)", border: "none", borderRadius: 10,
+              color: "#fff", fontSize: "0.88rem", fontWeight: 700, cursor: "pointer",
+              fontFamily: "var(--ff-body)", boxShadow: "0 4px 16px rgba(10,166,214,.4)",
+            }}
+          >
+            End Drill 🎯
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════
+   MAIN PAGE
+═══════════════════════════════════════ */
 const DrillTracking = () => {
   const { id: currentGameId } = useParams();
-  const currentGame = useSelector(state => state.games.byId[currentGameId]) || {};
-  const players = useSelector(state => state.players.byId);
-  const [selectedPlayers, setSelectedPlayers] = useState([]);
-  const [currentPlayer, setCurrentPlayer] = useState(null);
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const currentGame = useSelector((state) => state.games.byId[currentGameId]) || {};
+  const playersById = useSelector((state) => state.players.byId);
+
+  const selectedPlayers = useMemo(() => {
+    if (!currentGame?.playerIds) return [];
+    return currentGame.playerIds.map((id) => playersById[id]).filter(Boolean);
+  }, [currentGame?.playerIds, playersById]);
+
+  const [selPlayer, setSelPlayer] = useState(null);
+  const [showSelect, setShowSelect] = useState(false);
+  const [showEnd, setShowEnd] = useState(false);
+  const [showResults, setShowResults] = useState(false);
+  const [madeKey, setMadeKey] = useState(0);
+  const [floats, setFloats] = useState([]);
+  const [lastActions, setLastActions] = useState(currentGame.actions || []);
 
   useEffect(() => {
-    if (currentGame?.playerIds) {
-      const initialPlayers = currentGame.playerIds
-        .map(id => players[id])
-        .filter(player => player);
-      setSelectedPlayers(initialPlayers);
-      // Set the first player as current player
-      if (initialPlayers.length > 0) {
-        setCurrentPlayer(initialPlayers[0]);
-      }
+    if (selectedPlayers.length > 0 && !selPlayer) {
+      setSelPlayer(selectedPlayers[0]);
     }
-  }, [currentGame?.playerIds, players]);
+  }, [selectedPlayers]);
 
-  if (!currentGame) {
-    return <Navigate to="/games" />
-  }
+  useEffect(() => {
+    if (currentGame.id) {
+      dispatch(updateLastActions({ gameId: currentGame.id, actions: lastActions }));
+    }
+  }, [lastActions, dispatch, currentGame.id]);
 
-  const handlePlayerSelect = (player) => {
-    setCurrentPlayer(player);
+  const streak = useMemo(() => {
+    if (!lastActions.length || !selPlayer) return 0;
+    let s = 0;
+    for (let i = lastActions.length - 1; i >= 0; i--) {
+      const a = lastActions[i];
+      if (a.playerId !== selPlayer.id) break;
+      if (a.action === "addDrillCompletion") s++;
+      else break;
+    }
+    return s;
+  }, [lastActions, selPlayer]);
+
+  const addFloat = useCallback((made) => {
+    const id = Date.now() + Math.random();
+    setFloats((prev) => [...prev, { id, made, x: 35 + Math.random() * 30, y: 30 + Math.random() * 15 }]);
+    setTimeout(() => setFloats((prev) => prev.filter((f) => f.id !== id)), 1000);
+  }, []);
+
+  if (!currentGame?.id) return <Navigate to="/games" />;
+
+  const getStats = (playerId) =>
+    currentGame.stats?.[playerId] || { attempts: 0, completions: 0 };
+
+  const ps = selPlayer ? getStats(selPlayer.id) : null;
+  const pct = ps && ps.attempts > 0 ? Math.round((ps.completions / ps.attempts) * 100) : 0;
+
+  const handleMade = () => {
+    if (!selPlayer) { setShowSelect(true); return; }
+    dispatch(addDrillCompletion({ gameId: currentGame.id, playerId: selPlayer.id }));
+    setLastActions((prev) => [
+      ...prev.slice(-19),
+      { id: uuid(), action: "addDrillCompletion", gameId: currentGame.id, playerId: selPlayer.id, playerNumber: selPlayer.number },
+    ]);
+    setMadeKey((k) => k + 1);
+    addFloat(true);
   };
 
-  const totalStats = selectedPlayers.reduce((acc, player) => {
-    const playerStats = currentGame?.stats?.[player.id] || { completions: 0, attempts: 0 };
-    return {
-      completions: acc.completions + playerStats.completions,
-      attempts: acc.attempts + playerStats.attempts
-    };
-  }, { completions: 0, attempts: 0 });
+  const handleMiss = () => {
+    if (!selPlayer) { setShowSelect(true); return; }
+    dispatch(addDrillAttempt({ gameId: currentGame.id, playerId: selPlayer.id }));
+    setLastActions((prev) => [
+      ...prev.slice(-19),
+      { id: uuid(), action: "addDrillAttempt", gameId: currentGame.id, playerId: selPlayer.id, playerNumber: selPlayer.number },
+    ]);
+    addFloat(false);
+  };
 
-  const successRate = totalStats.attempts === 0 ? 0 : 
-    ((totalStats.completions / totalStats.attempts) * 100).toFixed(1);
+  const handleUndo = () => {
+    if (!lastActions.length) return;
+    dispatch(undoLastAction({ gameId: currentGame.id, actions: lastActions })); // reducer uses [last]
+    setLastActions((prev) => prev.slice(0, -1)); // remove newest (at end)
+  };
+
+  const handleEndDrill = () => {
+    dispatch(endGame(currentGame.id));
+    setShowEnd(false);
+    setShowResults(true);
+  };
+
+  const ringColor = pct >= 60 ? "var(--ht-cyan)" : "#ef4444";
+  const playersWithStats = selectedPlayers.map((p) => {
+    const s = getStats(p.id);
+    return { ...p, ...s, pct: s.attempts > 0 ? Math.round((s.completions / s.attempts) * 100) : 0 };
+  });
 
   return (
-    <div className="DrillTracking flex flex-col items-center w-full max-w-4xl mx-auto p-4 sm:p-6 lg:p-8 bg-black bg-opacity-50 rounded-lg shadow-xl text-white">
-      <BgImg />
-      <h2 className="text-2xl sm:text-3xl md:text-4xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-[#f64e07] to-[#0aa6d6] tracking-wider text-center">
-        Drill Tracking
-      </h2>
+    <div className="ht-game-screen">
+      <FloatParticles items={floats} />
 
-      {/* Stats Section */}
-      <div className="grid grid-cols-3 gap-2 mt-4 w-full sm:max-w-lg lg:max-w-3xl">
-        <div className="flex flex-col items-center space-y-1 bg-gray-800 bg-opacity-90 py-2 px-4 rounded-lg shadow-md">
-          <h3 className="text-sm sm:text-base font-semibold tracking-wide text-center">Total Attempts</h3>
-          <div className="text-3xl sm:text-4xl font-extrabold text-orange-600">{totalStats.attempts}</div>
-        </div>
-
-        <div className="flex flex-col items-center space-y-1 bg-gray-800 bg-opacity-90 py-2 px-4 rounded-lg shadow-md">
-          <h3 className="text-sm sm:text-base font-semibold tracking-wide text-center">Total Completions</h3>
-          <div className="text-3xl sm:text-4xl font-extrabold text-green-500">{totalStats.completions}</div>
-        </div>
-
-        <div className="flex flex-col items-center space-y-1 bg-gray-800 bg-opacity-90 py-2 px-4 rounded-lg shadow-md">
-          <h3 className="text-sm sm:text-base font-semibold tracking-wide text-center">Success Rate</h3>
-          <div className="text-3xl sm:text-4xl font-extrabold text-blue-600">{successRate}%</div>
-        </div>
-      </div>
-
-      {/* Selected Players Section */}
-      <div className="mt-6 flex flex-col items-center w-full">
-        <h3 className="text-lg font-semibold mb-2">Selected Players</h3>
-        <div className="flex flex-wrap gap-2">
-          {selectedPlayers.map(player => (
-            <span
-              key={player.id}
-              className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${
-                currentPlayer?.id === player.id
-                  ? 'bg-orange-100 text-orange-800'
-                  : 'bg-cyan-100 text-cyan-800'
-              }`}
-            >
-              {player.name}
-            </span>
-          ))}
+      {/* Header */}
+      <div
+        style={{
+          background: "linear-gradient(to bottom, #0a1115, var(--ht-bg1))",
+          padding: "14px 18px 12px",
+          borderBottom: "1px solid rgba(255,255,255,0.055)",
+          flexShrink: 0,
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div style={{ fontSize: "0.7rem", color: "var(--ht-muted)", display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--ht-cyan)", display: "inline-block", animation: "ht-pulse-dot 1.5s infinite" }} />
+            DRILL MODE
+          </div>
+          <div style={{ fontFamily: "var(--ff-display)", fontSize: "0.75rem", color: "var(--ht-cyan)", letterSpacing: "0.08em" }}>
+            🎯 {currentGame.name || "Drill"}
+          </div>
+          <button
+            onClick={() => setShowEnd(true)}
+            style={{
+              background: "rgba(10,166,214,.12)", border: "1px solid rgba(10,166,214,.3)", borderRadius: 7,
+              padding: "5px 10px", color: "var(--ht-cyan)", cursor: "pointer", fontSize: "0.72rem",
+              fontWeight: 700, letterSpacing: "0.07em", fontFamily: "var(--ff-body)",
+            }}
+          >
+            END 🏁
+          </button>
         </div>
       </div>
 
-      {/* Game Controls Section */}
-      <div className="mt-6 flex flex-col items-center w-full">
-        <GameControls 
-          mode="drill" 
-          currentPlayer={currentPlayer}
-          currentGameId={currentGame.id} 
-          selectedPlayers={selectedPlayers}
-          onPlayerSelect={handlePlayerSelect}
+      {/* Player chip */}
+      <div style={{ padding: "12px 16px 0", flexShrink: 0 }}>
+        <button
+          onClick={() => setShowSelect(true)}
+          style={{
+            width: "100%", padding: "11px 14px",
+            background: selPlayer ? "var(--ht-card2)" : "rgba(10,166,214,.08)",
+            border: `1.5px solid ${selPlayer ? "rgba(255,255,255,.09)" : "var(--ht-cyan)"}`,
+            borderRadius: 12, color: "var(--ht-text)",
+            display: "flex", alignItems: "center", gap: 10, cursor: "pointer", transition: "all 0.15s",
+          }}
+        >
+          {selPlayer ? (
+            <>
+              <div style={{
+                width: 36, height: 36, borderRadius: "50%", flexShrink: 0,
+                background: "var(--ht-cyan-dim)", border: "2px solid var(--ht-cyan)",
+                display: "flex", alignItems: "center", justifyContent: "center",
+                fontFamily: "var(--ff-display)", fontSize: "0.72rem", color: "var(--ht-cyan)",
+              }}>
+                {selPlayer.number}
+              </div>
+              <div style={{ flex: 1, textAlign: "left" }}>
+                <div style={{ fontSize: "0.95rem", fontWeight: 700, fontFamily: "var(--ff-body)" }}>{selPlayer.name}</div>
+                <div style={{ fontSize: "0.68rem", color: "var(--ht-muted)", marginTop: 1, fontFamily: "var(--ff-body)" }}>
+                  {ps?.attempts || 0} attempts · {ps?.completions || 0} made · {pct}%
+                </div>
+              </div>
+              {streak >= 2 && (
+                <div style={{ fontSize: "1.1rem", animation: "ht-fire-glow 1.4s ease-in-out infinite" }}>
+                  {streak >= 4 ? "🔥🔥" : "🔥"}
+                </div>
+              )}
+              <div style={{ color: "var(--ht-muted)", fontSize: "0.8rem" }}>›</div>
+            </>
+          ) : (
+            <>
+              <div style={{ width: 36, height: 36, borderRadius: "50%", background: "var(--ht-cyan-dim)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: "1.1rem", flexShrink: 0 }}>👆</div>
+              <div style={{ flex: 1, textAlign: "left", fontSize: "0.9rem", color: "var(--ht-cyan)", fontWeight: 600, fontFamily: "var(--ff-body)" }}>Select a Player</div>
+              <div style={{ color: "var(--ht-cyan)", fontSize: "0.8rem" }}>›</div>
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Main content area */}
+      <div
+        style={{
+          flex: 1, display: "flex", flexDirection: "column", alignItems: "center",
+          justifyContent: "center", padding: "12px 16px", gap: 12, minHeight: 0, overflowY: "auto",
+        }}
+      >
+        {selPlayer ? (
+          <>
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+              <ProgressRing
+                pct={pct}
+                size={148}
+                stroke={13}
+                color={ringColor}
+                label={`${ps?.completions || 0}/${ps?.attempts || 0}`}
+                sublabel="success"
+              />
+              {streak >= 2 && (
+                <div style={{
+                  display: "flex", alignItems: "center", gap: 8,
+                  background: "rgba(251,191,36,.1)", border: "1px solid rgba(251,191,36,.2)",
+                  borderRadius: 20, padding: "5px 14px",
+                }}>
+                  <div style={{ animation: "ht-fire-glow 1.2s ease-in-out infinite", fontSize: "1rem" }}>🔥</div>
+                  <div style={{ fontFamily: "var(--ff-display)", fontSize: "0.72rem", color: "var(--ht-gold)" }}>
+                    STREAK × {streak}
+                  </div>
+                  <div style={{ animation: "ht-fire-glow 1.2s ease-in-out infinite", fontSize: "1rem" }}>🔥</div>
+                </div>
+              )}
+            </div>
+
+            <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: 8 }}>
+              <button
+                key={madeKey}
+                className="ht-btn-made-drill flash"
+                onClick={handleMade}
+                style={{ height: 82, fontSize: "1.5rem" }}
+              >
+                <span style={{ position: "relative", zIndex: 1 }}>✓ MADE</span>
+                <span style={{ position: "relative", zIndex: 1, fontSize: "0.7rem", opacity: 0.85, letterSpacing: "0.1em" }}>
+                  COMPLETION
+                </span>
+              </button>
+              <button className="ht-btn-miss" onClick={handleMiss} style={{ height: 56, fontSize: "0.95rem" }}>
+                ✕&nbsp;&nbsp;MISS
+              </button>
+            </div>
+
+            <div style={{ display: "flex", gap: 8, width: "100%" }}>
+              <button
+                className="ht-btn-ghost"
+                onClick={handleUndo}
+                style={{ flex: 1, height: 40, fontSize: "0.75rem", letterSpacing: "0.06em" }}
+              >
+                ↩ UNDO
+              </button>
+              <button
+                onClick={() => setShowEnd(true)}
+                style={{
+                  flex: 2, height: 40, background: "rgba(10,166,214,.1)",
+                  border: "1.5px solid rgba(10,166,214,.3)", borderRadius: "var(--ht-rs)",
+                  color: "var(--ht-cyan)", fontFamily: "var(--ff-body)", fontSize: "0.82rem",
+                  fontWeight: 700, cursor: "pointer", letterSpacing: "0.07em",
+                }}
+              >
+                END DRILL 🏁
+              </button>
+            </div>
+          </>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12, opacity: 0.5 }}>
+            <div style={{
+              width: 140, height: 140, borderRadius: "50%",
+              border: "12px solid rgba(255,255,255,.06)",
+              display: "flex", alignItems: "center", justifyContent: "center", fontSize: "2.5rem",
+            }}>🎯</div>
+            <div style={{ fontSize: "0.85rem", color: "var(--ht-muted)", textAlign: "center", fontFamily: "var(--ff-body)" }}>
+              Select a player above<br />to start tracking
+            </div>
+          </div>
+        )}
+
+        {/* Mini rings for all players who have attempts */}
+        {playersWithStats.filter((p) => p.attempts > 0).length > 0 && (
+          <div style={{ width: "100%" }}>
+            <div style={{ fontSize: "0.6rem", color: "var(--ht-muted)", letterSpacing: "0.12em", fontWeight: 700, marginBottom: 8, textAlign: "center", fontFamily: "var(--ff-body)" }}>
+              ALL PLAYERS
+            </div>
+            <div style={{ display: "flex", justifyContent: "center", gap: 14, flexWrap: "wrap" }}>
+              {playersWithStats.filter((p) => p.attempts > 0).map((p) => (
+                <MiniRing key={p.id} pct={p.pct} name={p.name} pts={`${p.completions}/${p.attempts}`} />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {showSelect && (
+        <PlayerSheet
+          players={selectedPlayers}
+          selected={selPlayer}
+          onSelect={(p) => { setSelPlayer(p); setShowSelect(false); }}
+          onClose={() => setShowSelect(false)}
         />
-      </div>
+      )}
+      {showEnd && <EndModal onConfirm={handleEndDrill} onCancel={() => setShowEnd(false)} />}
+      {showResults && (
+        <div style={{ position: "fixed", inset: 0, display: "flex", justifyContent: "center", alignItems: "center", background: "rgba(0,0,0,0.9)", zIndex: 500 }}>
+          <div style={{ width: "100%", maxWidth: 480, maxHeight: "100vh", overflowY: "auto" }}>
+            <GameResult game={currentGame} onBackClick={() => setShowResults(false)} />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/PickUpGame/index.js
+++ b/src/pages/PickUpGame/index.js
@@ -1,18 +1,17 @@
 import React from "react";
-import { Navigate, useParams, useNavigate } from 'react-router-dom'
+import { Navigate, useParams, useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import Scoreboard from "../../components/Scoreboard";
 import GameControls from "../../components/GameControls";
-import "../../css/main.css";
-import BgImg from "../../components/BackgroundImage";
 import Icon from "../../components/Icon";
 
 const PickUpGame = () => {
   const { id: currentGameId } = useParams();
   const navigate = useNavigate();
   const currentGame = useSelector(state => state.games.byId[currentGameId]);
+
   if (!currentGame) {
-    return <Navigate to="/games" />
+    return <Navigate to="/games" />;
   }
 
   const handleReturnToTournament = () => {
@@ -22,23 +21,18 @@ const PickUpGame = () => {
   };
 
   return (
-    <div>
-      <div>
-        <div className="App">
-          <BgImg />
-          {currentGame.tournamentId && (
-            <button
-            onClick={handleReturnToTournament}
-            className="fixed top-4 left-4 z-50 flex items-center px-4 py-2 bg-white bg-opacity-20 backdrop-blur-sm rounded-lg text-[#f64e07] hover:text-white hover:bg-[#f64e07] font-semibold text-sm shadow-md transition-all"
-          >
-            <Icon type="arrow-left" size={16} className="mr-2" />
-            Back to Tournament
-          </button>
-          )}
-          <Scoreboard currentGameId={currentGameId} />
-          <GameControls currentGameId={currentGameId} />
-        </div>
-      </div>
+    <div className="ht-game-screen">
+      {currentGame.tournamentId && (
+        <button
+          onClick={handleReturnToTournament}
+          className="fixed top-4 left-4 z-50 flex items-center px-4 py-2 bg-white bg-opacity-10 backdrop-blur-sm rounded-lg text-[#f64e07] hover:text-white hover:bg-[#f64e07] font-semibold text-sm shadow-md transition-all"
+        >
+          <Icon type="arrow-left" size={16} className="mr-2" />
+          Back to Tournament
+        </button>
+      )}
+      <Scoreboard currentGameId={currentGameId} />
+      <GameControls currentGameId={currentGameId} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- **Design system**: Barlow Condensed font, `--ht-*` CSS custom properties, keyframe animations (confetti, score-float, MADE flash, fire glow, win-reveal, shimmer, pulse), reusable button classes
- **Live scoring**: Shot-type pills (1PT·FT / 2PT / 3PT·ARC), 88px MADE button with orange gradient glow flash, quieter red MISS button, player chip with live FG%, 🔥 streak indicator, floating score particles, live leaderboard strip, action feed
- **Drill mode**: Animated SVG progress ring (green ≥60% / red <60%), 🔥 streak badge, green MADE button, mini rings per player
- **Game results**: Confetti, animated winner reveal, MVP card with shimmer, stats table with team tabs, player profile modal with shooting efficiency bars, social share section (Twitter / WhatsApp / Copy + branded game recap card)

## Test plan

- [ ] Start a pick-up game → select a player → tap MADE and verify orange glow flash + floating score particle + leaderboard strip appears
- [ ] Score 2+ in a row → verify 🔥 streak shows on player chip
- [ ] Switch shot type pill (1PT / 2PT / 3PT) → tap MADE → confirm correct points added to scoreboard
- [ ] Tap MISS → verify red MISS button dims and streak resets
- [ ] Tap UNDO → verify last action is reversed in Redux and action feed
- [ ] End a game → confirm confetti fires, winner reveal animates, MVP card shows
- [ ] Tap a player row in results → player profile modal opens with shooting bars
- [ ] Share buttons (Twitter / WhatsApp / Copy) open correct targets
- [ ] Start a drill → select a player → tap MADE → verify progress ring fills green
- [ ] Score 2+ makes in a row in drill → verify 🔥 STREAK × N badge appears
- [ ] Tap MISS in drill → ring turns red if below 60%
- [ ] Multiple players with drill attempts → mini rings appear at bottom
- [ ] App builds without errors (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)