### PR TITLE
Add View stats entry on Games list (HT-021)

### DIFF
--- a/src/components/GameResults.js
+++ b/src/components/GameResults.js
@@ -469,12 +469,22 @@ const GameResults = ({ game, onBackClick }) => {
           {shownPlayers.map((p, i) => {
             const s = game.stats?.[shownTeamId]?.[p.id] || { ...initialStats };
             const isMvp = mvp?.player?.id === p.id;
+            const fg2m = getFgm(s) - getTpm(s);
+            const fg2a = getFga(s) - getTpa(s);
+            const fg2Pct = fg2a > 0 ? Math.round((fg2m / fg2a) * 100) : 0;
+            const tpm = getTpm(s);
+            const tpa = getTpa(s);
+            const tpPct = getTpPct(s);
+            const ftm = getFtm(s);
+            const fta = getFta(s);
+            const ftPct = getFtPct(s);
+            const hasShots = fg2a > 0 || tpa > 0 || fta > 0;
             return (
               <div
                 key={p.id}
                 onClick={() => setProfilePlayer(p)}
                 style={{
-                  display: "grid", gridTemplateColumns: "2fr repeat(4, 1fr)", gap: 4, padding: "10px 12px",
+                  padding: "10px 12px",
                   borderBottom: i < shownPlayers.length - 1 ? "1px solid rgba(255,255,255,.03)" : "none",
                   background: isMvp ? "rgba(251,191,36,.035)" : "transparent",
                   cursor: "pointer", transition: "background 0.15s",
@@ -482,16 +492,87 @@ const GameResults = ({ game, onBackClick }) => {
                 onMouseEnter={(e) => e.currentTarget.style.background = isMvp ? "rgba(251,191,36,.07)" : "rgba(255,255,255,.03)"}
                 onMouseLeave={(e) => e.currentTarget.style.background = isMvp ? "rgba(251,191,36,.035)" : "transparent"}
               >
-                <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
-                  <span style={{ fontSize: "0.7rem", color: "var(--ht-muted)", fontFamily: "var(--ff-display)", minWidth: 22 }}>#{p.number}</span>
-                  <span style={{ fontSize: "0.83rem", fontWeight: isMvp ? 700 : 400, color: isMvp ? "var(--ht-gold)" : "var(--ht-text)" }}>
-                    {p.name}{isMvp ? " 👑" : ""}
-                  </span>
-                  <span style={{ fontSize: "0.55rem", color: "var(--ht-dim)", marginLeft: "auto" }}>›</span>
+                <div style={{ display: "grid", gridTemplateColumns: "2fr repeat(4, 1fr)", gap: 4 }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+                    <span style={{ fontSize: "0.7rem", color: "var(--ht-muted)", fontFamily: "var(--ff-display)", minWidth: 22 }}>#{p.number}</span>
+                    <span style={{ fontSize: "0.83rem", fontWeight: isMvp ? 700 : 400, color: isMvp ? "var(--ht-gold)" : "var(--ht-text)" }}>
+                      {p.name}{isMvp ? " 👑" : ""}
+                    </span>
+                    <span style={{ fontSize: "0.55rem", color: "var(--ht-dim)", marginLeft: "auto" }}>›</span>
+                  </div>
+                  {[getPts(s), getReb(s), getAst(s), getFouls(s)].map((v, j) => (
+                    <div key={j} style={{ textAlign: "center", fontFamily: "var(--ff-display)", fontSize: "0.82rem", color: v > 0 ? "var(--ht-text)" : "var(--ht-dim)" }}>{v}</div>
+                  ))}
                 </div>
-                {[getPts(s), getReb(s), getAst(s), getFouls(s)].map((v, j) => (
-                  <div key={j} style={{ textAlign: "center", fontFamily: "var(--ff-display)", fontSize: "0.82rem", color: v > 0 ? "var(--ht-text)" : "var(--ht-dim)" }}>{v}</div>
-                ))}
+                {hasShots ? (
+                  <div
+                    style={{
+                      display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 6,
+                      marginTop: 6, paddingLeft: 30,
+                    }}
+                  >
+                    {[
+                      { label: "2PT", made: fg2m, att: fg2a, pct: fg2Pct, color: "var(--ht-orange)" },
+                      { label: "3PT", made: tpm, att: tpa, pct: tpPct, color: "var(--ht-gold)" },
+                      { label: "FT", made: ftm, att: fta, pct: ftPct, color: "var(--ht-cyan)" },
+                    ].map(({ label, made, att, pct, color }) => {
+                      const miss = att - made;
+                      const attempted = att > 0;
+                      return (
+                        <div
+                          key={label}
+                          style={{
+                            display: "flex", flexDirection: "column", alignItems: "center",
+                            background: "rgba(255,255,255,.025)",
+                            borderLeft: `2px solid ${attempted ? color : "rgba(255,255,255,.06)"}`,
+                            borderRadius: 4, padding: "4px 6px",
+                          }}
+                        >
+                          <div
+                            style={{
+                              fontSize: "0.52rem", color: "var(--ht-muted)",
+                              letterSpacing: "0.08em", fontWeight: 700,
+                              marginBottom: 2, fontFamily: "var(--ff-body)",
+                            }}
+                          >
+                            {label}
+                          </div>
+                          <div
+                            style={{
+                              fontSize: "0.72rem", color: attempted ? "var(--ht-text)" : "var(--ht-dim)",
+                              fontFamily: "var(--ff-display)", lineHeight: 1.1,
+                            }}
+                          >
+                            {made}/{att}
+                          </div>
+                          <div
+                            style={{
+                              fontSize: "0.56rem",
+                              color: attempted ? color : "var(--ht-dim)",
+                              fontWeight: 700, marginTop: 2, fontFamily: "var(--ff-body)",
+                            }}
+                          >
+                            {attempted ? `${pct}%` : "—"}
+                            {miss > 0 && (
+                              <span style={{ color: "var(--ht-muted)", marginLeft: 4, fontWeight: 400 }}>
+                                · {miss} miss
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div
+                    style={{
+                      fontSize: "0.58rem", color: "var(--ht-dim)",
+                      marginTop: 4, paddingLeft: 30, fontFamily: "var(--ff-body)",
+                    }}
+                  >
+                    No shooting attempts
+                  </div>
+                )}
               </div>
             );
           })}

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import AddPickUpGame from './pages/AddPickUpGame';
 import AddTeam from './pages/AddTeam';
 import PickUpGame from './pages/PickUpGame';
 import DrillTracking from './pages/DrillTracking';
+import GameStats from './pages/GameStats';
 import EditTeam from './pages/EditTeam';
 import EditPlayer from './pages/EditPlayer';
 import AddPlayer from './pages/AddPlayer';
@@ -158,6 +159,18 @@ const router = createBrowserRouter([
     path: 'games/drill/:id',
     element: <Protected>
       <DrillTracking />
+    </Protected>
+  },
+  {
+    path: 'games/pick-up-game/:id/stats',
+    element: <Protected>
+      <GameStats />
+    </Protected>
+  },
+  {
+    path: 'games/drill/:id/stats',
+    element: <Protected>
+      <GameStats />
     </Protected>
   },
 ]);

--- a/src/pages/GameStats/index.js
+++ b/src/pages/GameStats/index.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { useSelector } from "react-redux";
+import GameResults from "../../components/GameResults";
+
+/**
+ * Standalone "View stats" route. Mounts <GameResults> against a game already
+ * present in Redux (either freshly loaded from Firestore or rehydrated from
+ * localStorage via redux-persist) so a user can review their full made/miss
+ * breakdown without having to trigger the end-game flow from GameControls.
+ *
+ * Works for both pick-up and drill games — GameResults handles both shapes.
+ *
+ * If the game isn't in state.games.byId (e.g. cold load, different browser),
+ * we redirect to /games rather than render an empty shell. A future task
+ * (HT-021 follow-up) can wire a Firestore fetch here for finished games.
+ */
+const GameStats = () => {
+  const { id: currentGameId } = useParams();
+  const navigate = useNavigate();
+  const currentGame = useSelector(
+    (state) => state.games.byId[currentGameId]
+  );
+
+  if (!currentGame) {
+    return <Navigate to="/games" replace />;
+  }
+
+  return (
+    <div
+      className="ht-game-screen"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.95)",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "flex-start",
+        overflowY: "auto",
+        zIndex: 100,
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: 480, padding: "1rem 0" }}>
+        <GameResults
+          game={currentGame}
+          onBackClick={() => navigate("/games")}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default GameStats;

--- a/src/pages/Games/index.js
+++ b/src/pages/Games/index.js
@@ -4,6 +4,7 @@ import { useSelector, useDispatch } from "react-redux";
 import {
   TrashIcon,
   PlusIcon,
+  ChartBarIcon,
 } from "@heroicons/react/24/solid";
 import SportsBasketballIcon from '@mui/icons-material/SportsBasketball';
 
@@ -74,12 +75,24 @@ export default function AddGame() {
     }
   };
 
+  const onViewStats = game => {
+    if (game.type === 'pick-up') {
+      navigate(`/games/pick-up-game/${game.id}/stats`);
+      return;
+    }
+
+    if (game.type === 'drill') {
+      navigate(`/games/drill/${game.id}/stats`);
+    }
+  };
+
   const onDeleteGame = game => {
     dispatch(deleteGame(game.id))
   };
 
 
   const dropdownItems = [
+    { text: 'View stats', icon: ChartBarIcon, onClick: onViewStats },
     { text: 'Resume game', icon: () => <SportsBasketballIcon className="!w-4 !h-4" />, onClick: onResumeGame },
     { text: 'Delete', icon: TrashIcon, onClick: onDeleteGame },
   ];


### PR DESCRIPTION
## Summary
- Adds a new **View stats** entry to the Games-list dropdown menu (ordered above Resume / Delete) so finished and in-progress games' full stat breakdowns are reachable without triggering end-game again
- New routes `/games/pick-up-game/:id/stats` and `/games/drill/:id/stats` mount `<GameResults>` against a game pulled from Redux (works for redux-persist rehydrated localStorage state)
- New page `src/pages/GameStats/index.js` — redirects to `/games` when the game isn't in Redux (cold-load Firestore fetch left as HT-021 follow-up)
- **Inline per-player shooting splits** in the team stats table: each player row now shows `2PT / 3PT / FT` with `made/attempted`, `pct%`, and explicit miss count. Tapping the row still opens the full PlayerProfile

## Why
Tracks HT-021. After the v2 UI redesign (PR #39), the Games-list menu only exposed Resume / Delete, so the rich made/miss/% breakdown was unreachable on finished games without triggering end-game again. This also blocks Jason from seeing the stats from his 2026-06-01 game (rehydrated from localStorage but never finalized through the new flow). Opening **View stats** on his rehydrated game lets him see the full per-player shooting breakdown AND tap **Save & Exit**, which now calls `pushStatsToFirebase` (shipped via PRs #38/#39), persisting the entire stats map to Firestore.

## Test plan
- [ ] Sign in on https://hoop-trackr.web.app → land on Games list
- [ ] Open the dropdown on a finished game → see **View stats** as the first item
- [ ] Click **View stats** → opens `<GameResults>` with score, MVP, per-team table
- [ ] Each player row shows 2PT / 3PT / FT made-attempted-percentage + miss count inline
- [ ] Tapping a player row still opens the full PlayerProfile modal
- [ ] **← Back** returns to `/games`
- [ ] **Save & Exit** writes the full stats map to Firestore (verify via Firestore console)
- [ ] Direct nav to `/games/pick-up-game/<bad-id>/stats` redirects to `/games`
- [ ] Drill games work the same way under `/games/drill/:id/stats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)